### PR TITLE
Command restructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_executable(jabs main.c sample.c sample.h brick.c ion.c ion.h simulation.c si
         options.c options.h spectrum.c spectrum.h fit.c fit.h rotate.c rotate.h detector.c detector.h jabs.c jabs.h
         roughness.c roughness.h script.c script.h generic.c generic.h message.c message.h aperture.c aperture.h
         geostragg.c geostragg.h script_command.c script_command.h script_session.c script_session.h script_file.c
-        script_file.h calibration.c calibration.h)
+        script_file.h calibration.c calibration.h script_generic.h)
 
 target_include_directories(jabs PRIVATE ${GETOPT_INCLUDE_DIR})
 

--- a/aperture.c
+++ b/aperture.c
@@ -72,6 +72,17 @@ aperture *aperture_from_argv(const jibal *jibal, int * const argc, char * const 
         return NULL;
     }
 
+#if 0
+    jibal_config_var vars[] = {
+            {JIBAL_CONFIG_VAR_UNIT, "width",    &a->width,    NULL},
+            {JIBAL_CONFIG_VAR_UNIT, "height",   &a->height,   NULL},
+            {JIBAL_CONFIG_VAR_UNIT, "diameter", &a->diameter, NULL},
+            {JIBAL_CONFIG_VAR_NONE, NULL, NULL,               NULL}
+    };
+#endif
+
+
+
     while((*argc) >= 2) {
         if(strcmp((*argv)[0], "width") == 0) {
             a->width = jibal_get_val(jibal->units, UNIT_TYPE_DISTANCE, (*argv)[1]);

--- a/calibration.c
+++ b/calibration.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include "generic.h"
 #include "calibration.h"
 
 calibration *calibration_init() {
@@ -66,4 +67,27 @@ int calibration_set_param(calibration *c, calibration_param_type type, double va
             return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;
+}
+
+double calibration_get_param(const calibration *c, calibration_param_type type) {
+    if(!c || !c->params)
+        return 0.0;
+    if(c->type != CALIBRATION_LINEAR)
+        return 0.0;
+    calibration_params_linear *p = (calibration_params_linear *) c->params;
+    switch(type) {
+        case CALIBRATION_PARAM_OFFSET:
+            return p->offset;
+        case CALIBRATION_PARAM_SLOPE:
+            return p->slope;
+        default:
+            break;
+    }
+    return 0.0;
+}
+
+const char *calibration_name(const calibration *c) {
+    if(!c)
+        return calibration_option[CALIBRATION_NONE].s;
+    return calibration_option[c->type].s;
 }

--- a/calibration.c
+++ b/calibration.c
@@ -1,0 +1,69 @@
+#include <assert.h>
+#include "calibration.h"
+
+calibration *calibration_init() {
+    calibration *c = malloc(sizeof(calibration));
+    if(!c)
+        return NULL;
+    c->f = NULL;
+    c->type = CALIBRATION_NONE;
+    c->params = NULL;
+    return c;
+}
+
+void calibration_free(calibration *c) {
+    if(!c)
+        return;
+    free(c->params);
+    free(c);
+}
+
+calibration *calibration_init_linear(double offset, double slope) {
+    calibration *c = calibration_init();
+    if(!c)
+        return NULL;
+    c->f = calibration_linear;
+    c->type = CALIBRATION_LINEAR;
+    calibration_params_linear *p = malloc(sizeof(calibration_params_linear));
+    p->offset = offset;
+    p->slope = slope;
+    c->params = p;
+    return c;
+}
+
+
+
+double calibration_linear(const void *params, double x) {
+    calibration_params_linear *p = (calibration_params_linear *)params;
+    return p->offset + p->slope * x;
+}
+
+double calibration_eval(const calibration *c, double x) {
+    if(c->type == CALIBRATION_NONE) {
+        return x;
+    } else {
+        assert(c->f);
+        return c->f(c->params, x);
+    }
+}
+
+int calibration_set_param(calibration *c, calibration_param_type type, double value) {
+    if(!c || !c->params)
+        return EXIT_FAILURE;
+    if(c->type != CALIBRATION_LINEAR)
+        return EXIT_FAILURE;
+    calibration_params_linear *p = (calibration_params_linear *) c->params;
+    switch(type) {
+        case CALIBRATION_PARAM_NONE:
+            break;
+        case CALIBRATION_PARAM_OFFSET:
+            p->offset = value;
+            break;
+        case CALIBRATION_PARAM_SLOPE:
+            p->slope = value;
+            break;
+        default:
+            return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}

--- a/calibration.c
+++ b/calibration.c
@@ -6,7 +6,7 @@ calibration *calibration_init() {
     calibration *c = malloc(sizeof(calibration));
     if(!c)
         return NULL;
-    c->f = NULL;
+    c->f = calibration_none;
     c->type = CALIBRATION_NONE;
     c->params = NULL;
     return c;
@@ -39,13 +39,8 @@ double calibration_linear(const void *params, double x) {
     return p->offset + p->slope * x;
 }
 
-double calibration_eval(const calibration *c, double x) {
-    if(c->type == CALIBRATION_NONE) {
-        return x;
-    } else {
-        assert(c->f);
-        return c->f(c->params, x);
-    }
+double calibration_none(const void *params, double x) {
+    return x;
 }
 
 int calibration_set_param(calibration *c, calibration_param_type type, double value) {
@@ -84,6 +79,23 @@ double calibration_get_param(const calibration *c, calibration_param_type type) 
             break;
     }
     return 0.0;
+}
+
+double *calibration_get_param_ref(calibration *c, calibration_param_type type) {
+    if(!c || !c->params)
+        return NULL;
+    if(c->type != CALIBRATION_LINEAR)
+        return NULL;
+    calibration_params_linear *p = (calibration_params_linear *) c->params;
+    switch(type) {
+        case CALIBRATION_PARAM_OFFSET:
+            return &(p->offset);
+        case CALIBRATION_PARAM_SLOPE:
+            return &(p->slope);
+        default:
+            break;
+    }
+    return NULL;
 }
 
 const char *calibration_name(const calibration *c) {

--- a/calibration.h
+++ b/calibration.h
@@ -38,8 +38,10 @@ calibration *calibration_init();
 void calibration_free(calibration *c);
 calibration *calibration_init_linear(double offset, double slope);
 double calibration_linear(const void *params, double x);
-double calibration_eval(const calibration *c, double x);
+double calibration_none(const void *params, double x);
+inline double calibration_eval(const calibration *c, double x) {return c->f(c->params, x);}
 int calibration_set_param(calibration *c, calibration_param_type type, double value);
 double calibration_get_param(const calibration *c, calibration_param_type type);
+double *calibration_get_param_ref(calibration *c, calibration_param_type type);
 const char *calibration_name(const calibration *c);
 #endif //CALIB_CALIBRATION_H

--- a/calibration.h
+++ b/calibration.h
@@ -1,0 +1,36 @@
+#ifndef CALIB_CALIBRATION_H
+#define CALIB_CALIBRATION_H
+#include <inttypes.h>
+#include <stdlib.h>
+
+typedef enum calibration_type {
+    CALIBRATION_NONE = 0,
+    CALIBRATION_ARB = 1,
+    CALIBRATION_LINEAR = 2
+} calibration_type;
+
+typedef enum calibration_param_type {
+    CALIBRATION_PARAM_NONE = 0,
+    CALIBRATION_PARAM_OFFSET = 1,
+    CALIBRATION_PARAM_SLOPE = 2
+} calibration_param_type;
+
+
+typedef struct calibration {
+    calibration_type type;
+    double (*f)(const void *, double);
+    void *params;
+} calibration;
+
+typedef struct calibration_params_linear {
+    double offset;
+    double slope;
+} calibration_params_linear;
+
+calibration *calibration_init();
+void calibration_free(calibration *c);
+calibration *calibration_init_linear(double offset, double slope);
+double calibration_linear(const void *params, double x);
+double calibration_eval(const calibration *c, double x);
+int calibration_set_param(calibration *c, calibration_param_type type, double value);
+#endif //CALIB_CALIBRATION_H

--- a/calibration.h
+++ b/calibration.h
@@ -2,6 +2,7 @@
 #define CALIB_CALIBRATION_H
 #include <inttypes.h>
 #include <stdlib.h>
+#include <jibal_option.h>
 
 typedef enum calibration_type {
     CALIBRATION_NONE = 0,
@@ -9,12 +10,18 @@ typedef enum calibration_type {
     CALIBRATION_LINEAR = 2
 } calibration_type;
 
+static const jibal_option calibration_option[] = {
+        {JIBAL_OPTION_STR_NONE, CALIBRATION_NONE},
+        {"arbitrary", CALIBRATION_ARB},
+        {"linear", CALIBRATION_LINEAR},
+        {NULL, 0}
+};
+
 typedef enum calibration_param_type {
     CALIBRATION_PARAM_NONE = 0,
     CALIBRATION_PARAM_OFFSET = 1,
     CALIBRATION_PARAM_SLOPE = 2
 } calibration_param_type;
-
 
 typedef struct calibration {
     calibration_type type;
@@ -33,4 +40,6 @@ calibration *calibration_init_linear(double offset, double slope);
 double calibration_linear(const void *params, double x);
 double calibration_eval(const calibration *c, double x);
 int calibration_set_param(calibration *c, calibration_param_type type, double value);
+double calibration_get_param(const calibration *c, calibration_param_type type);
+const char *calibration_name(const calibration *c);
 #endif //CALIB_CALIBRATION_H

--- a/defaults.h
+++ b/defaults.h
@@ -16,7 +16,9 @@
 #define COPYRIGHT_STRING "\n    This program is free software; you can redistribute it and/or modify \n    it under the terms of the GNU General Public License as published by\n    the Free Software Foundation; either version 2 of the License, or\n    (at your option) any later version.\n\n   See LICENSE.txt for the full license.\n\n"
 #include <jibal_units.h>
 
-#define SCRIPT_NESTED_MAX 8 /* How deep (number of levels) scripts can be nested, i.e. script file loads a script file loads a script file... */
+#define SCRIPT_FILES_NESTED_MAX 8 /* How deep (number of levels) scripts can be nested, i.e. script file loads a script file loads a script file... */
+#define SCRIPT_COMMANDS_NESTED_MAX 8 /* How deep (number of levels) script commands can be nested, i.e. script command has a subcommand, which has a subcommand... */
+#define SCRIPT_COMMAND_MERGE_SORT_ARRAY_SIZE 16 /* Commands are sorted alphabetically using a merge sort, the algorithm uses a "Bottom-up" approach with a small fixed size array (can sort up to 2^SCRIPT_COMMAND_MERGE_SORT_ARRAY_SIZE elements) */
 #define PROMPT "jabs> "
 
 /* Defaults for new simulations */

--- a/detector.c
+++ b/detector.c
@@ -132,6 +132,7 @@ detector *detector_default(detector *det) {
     det->channels = 16384;
     det->compress = 1;
     det->foil = NULL;
+    det->foil_sm = NULL;
     return det;
 }
 

--- a/detector.c
+++ b/detector.c
@@ -195,7 +195,7 @@ int detector_print(const char *filename, const detector *det) {
 int detector_aperture_set_from_argv(const jibal *jibal, detector *det, int *argc, char * const **argv) {
     aperture *a = aperture_from_argv(jibal, argc, argv);
     if(a) {
-        free(det->aperture);
+        aperture_free(det->aperture);
         det->aperture = a;
     } else {
         return EXIT_FAILURE;

--- a/detector.c
+++ b/detector.c
@@ -331,5 +331,7 @@ double detector_resolution(const detector *det, const jibal_isotope *isotope, do
 
 void detector_update(detector *det) {
     det->resolution_variance = pow2(det->resolution/C_FWHM);
+#ifdef DEBUG
     fprintf(stderr, "Updated detector, resolution = %g keV FWHM, variance = %g\n", det->resolution/C_KEV, det->resolution_variance);
+#endif
 }

--- a/detector.h
+++ b/detector.h
@@ -39,8 +39,6 @@ static const jibal_option detector_option[] = {
 
 typedef struct detector {
     detector_type type;
-    double slope; /* TODO: use .calibration */
-    double offset;
     struct calibration *calibration;
     double length; /* For ToF */
     double resolution; /* Stored as FWHM in relevant SI units. Note that can be e.g. energy or time depending on detector type. */
@@ -57,7 +55,7 @@ typedef struct detector {
     sample *foil;
 } detector;
 
-inline double detector_calibrated(const detector *det, size_t ch) {return det->offset + det->slope * (unsigned int)(ch*det->compress);}
+inline double detector_calibrated(const detector *det, size_t ch) {return calibration_eval(det->calibration, ch*det->compress);}
 char *detector_calibration_to_string(const detector *det);
 const char *detector_type_name(const detector *det);
 int detector_sanity_check(const detector *det);
@@ -76,6 +74,6 @@ double detector_theta_deriv(const detector *det, char direction);
 double detector_solid_angle_calc(const detector *det);
 double detector_resolution(const detector *det, const jibal_isotope *isotope, double E);
 void detector_update(detector *det);
-const char *detector_param_unit(const detector *det);
+const char *detector_param_unit(const detector *det); /* return a suitable unit based on detector type, e.g. "keV" when type == DETECTOR_ENERGY. TODO: use this wisely (we can simulate energy spectra with a ToF detector!) */
 double detector_param_unit_factor(const detector *det);
 #endif //JABS_DETECTOR_H

--- a/detector.h
+++ b/detector.h
@@ -20,6 +20,7 @@
 #include "sample.h"
 #include "aperture.h"
 #include "rotate.h"
+#include "calibration.h"
 
 typedef enum {
     DETECTOR_NONE = 0,
@@ -38,8 +39,9 @@ static const jibal_option detector_option[] = {
 
 typedef struct detector {
     detector_type type;
-    double slope;
+    double slope; /* TODO: use .calibration */
     double offset;
+    struct calibration *calibration;
     double length; /* For ToF */
     double resolution; /* Stored as FWHM in relevant SI units. Note that can be e.g. energy or time depending on detector type. */
     double resolution_variance; /* Calculated based on "resolution" before needed by detector_update(). */
@@ -56,6 +58,7 @@ typedef struct detector {
 } detector;
 
 inline double detector_calibrated(const detector *det, size_t ch) {return det->offset + det->slope * (unsigned int)(ch*det->compress);}
+char *detector_calibration_to_string(const detector *det);
 const char *detector_type_name(const detector *det);
 int detector_sanity_check(const detector *det);
 detector *detector_from_file(const jibal *jibal, const char *filename); /* one detector from JIBAL configuration style file */
@@ -73,4 +76,6 @@ double detector_theta_deriv(const detector *det, char direction);
 double detector_solid_angle_calc(const detector *det);
 double detector_resolution(const detector *det, const jibal_isotope *isotope, double E);
 void detector_update(detector *det);
+const char *detector_param_unit(const detector *det);
+double detector_param_unit_factor(const detector *det);
 #endif //JABS_DETECTOR_H

--- a/example/example.jbs
+++ b/example/example.jbs
@@ -26,7 +26,7 @@ set maxiter 100
 
 simulate
 save spectra "simulated_out.csv"
-fit calib,fluence,thickness1,thickness2,rough1
+#fit calib,fluence,thickness1,thickness2,rough1
 save spectra "out.csv"
 save det "det_out.txt"
 #fitted sample can be saved (and loaded back in later!)

--- a/example/example.jbs
+++ b/example/example.jbs
@@ -26,7 +26,8 @@ set maxiter 100
 
 simulate
 save spectra "simulated_out.csv"
-#fit calib,fluence,thickness1,thickness2,rough1
+
+fit calib,fluence,thickness1,thickness2,rough1
 save spectra "out.csv"
 save det "det_out.txt"
 #fitted sample can be saved (and loaded back in later!)

--- a/example/example.jbs
+++ b/example/example.jbs
@@ -21,9 +21,8 @@ set det theta 160deg phi 90deg solid 5msr
 #Detector can also be loaded from a file
 #load det "detector.txt"
 
-add fit_range 200 700
-add fit_range 1050 1100
-set fit_maxiter 100
+add fit range [200:700] [1050:1110]
+set maxiter 100
 
 simulate
 save spectra "simulated_out.csv"

--- a/example/tests/geo_Co_cornell.jbs
+++ b/example/tests/geo_Co_cornell.jbs
@@ -3,18 +3,10 @@ set ion 7Li
 set geostragg true
 set energy 2MeV
 set alpha 50deg
-set sample_azi 0deg
-set beam_aperture rectangle
-set beam_aperture_width 5mm
-set beam_aperture_height 4mm
-#set beam_aperture circle
-#set beam_aperture_diameter 10mm
-set det theta 120deg
-set det phi 90deg
-set det resolution 10keV
-set det aperture circle
-set det aperture_diameter 8mm
-set det distance 100mm
+set phi 0deg
+set aperture rectangle width 5mm height 4mm
+set det theta 120deg phi 90deg slope 1keV resolution 10keV
+set det aperture circle diameter 8mm distance 100mm
 set sample Co 2000tfu
 add reactions RBS
 simulate

--- a/example/tests/nra_test.jbs
+++ b/example/tests/nra_test.jbs
@@ -1,14 +1,16 @@
-#Reaction 7Li(p,a)4He from file "li7pa0n.r33"
-load reaction "li7pa0n.r33"
-set sample "6Li0.075 7Li0.925 O2" 12000tfu Si 10000tfu
-#set sample LiO2 12000tfu Si 10000tfu
-set ion p
-set energy 2.2MeV
-set det theta 160deg
+#!/usr/bin/env jabs
+set ion p energy 2.2MeV
+set det theta 160deg solid 70msr
 set det slope 2keV
 set fluence 1e13
-set det solid 70msr
+
+set sample "6Li0.075 7Li0.925 O2" 12000tfu Si 10000tfu
+#Note: isotopic ratios of Li may vary, the commented command below will set them with defaults from JIBAL
+#set sample LiO2 12000tfu Si 10000tfu
+
+#Reaction 7Li(p,a)4He from file "li7pa0n.r33"
+load reaction "li7pa0n.r33"
+add reactions RBS
 show reactions
-set stop_step_fudge 0.5
 simulate
 save spectra "out.csv"

--- a/fit.c
+++ b/fit.c
@@ -412,12 +412,12 @@ int fit(struct fit_data *fit_data) {
         detector *det = sim_det(fit_data->sim, range->i_det);
         gsl_histogram *exp = fit_data_exp(fit_data, range->i_det);
         if(!det) {
-            jabs_message(MSG_ERROR, stderr, "Detector %zu (fit range %zu) does not exist.\n", range->i_det, i_range);
+            jabs_message(MSG_ERROR, stderr, "Detector %zu (fit range %zu) does not exist.\n", range->i_det + 1, i_range + 1);
             free(weights);
             return 1;
         }
         if(!exp) {
-            jabs_message(MSG_ERROR, stderr,  "Experimental spectrum for detector %zu (fit range %zu) does not exist.\n", range->i_det, i_range);
+            jabs_message(MSG_ERROR, stderr,  "Experimental spectrum for detector %zu (fit range %zu) does not exist.\n", range->i_det + 1, i_range + 1);
             free(weights);
             return 1;
         }

--- a/fit.c
+++ b/fit.c
@@ -138,7 +138,10 @@ void fit_stats_print(FILE *f, const struct fit_stats *stats) {
 }
 
 int fit_data_fit_range_add(struct fit_data *fit_data, const struct roi *range) { /* Makes a deep copy */
-    if(range->high < range->low || range->high == 0) {
+    if(range->low == 0 && range->high == 0) {
+        return EXIT_FAILURE;
+    }
+    if(range->high < range->low) {
         jabs_message(MSG_ERROR, stderr, "Range from %zu to %zu is not valid!\n", range->low, range->high);
         return EXIT_FAILURE;
     }

--- a/fit.c
+++ b/fit.c
@@ -113,11 +113,26 @@ fit_params *fit_params_new() {
     p->func_params_err = NULL;
     return p;
 }
-void fit_params_add_parameter(fit_params *p, double *value) {
+int fit_params_add_parameter(fit_params *p, double *value) {
+    if(!value) {
+#ifdef DEBUG
+        fprintf(stderr, "Didn't add a fit parameter since a NULL pointer was passed.\n");
+#endif
+        return EXIT_FAILURE;
+    }
+    for(size_t i = 0; i < p->n; i++) {
+        if(p->func_params[i] == value) {
+#ifdef DEBUG
+            fprintf(stderr, "Didn't add fit parameter that points to value %p\n", (void *)value);
+#endif
+            return EXIT_SUCCESS; /* Parameter already exists, don't add. */
+        }
+    }
     p->n++;
     p->func_params = realloc(p->func_params, sizeof(double *)*p->n);
     p->func_params_err = realloc(p->func_params_err, sizeof(double)*p->n);
     p->func_params[p->n-1] = value;
+    return EXIT_SUCCESS;
 }
 void fit_params_free(fit_params *p) {
     if(!p)

--- a/fit.h
+++ b/fit.h
@@ -86,6 +86,7 @@ fit_params *fit_params_new();
 void fit_params_add_parameter(fit_params *p, double *value);
 void fit_params_free(fit_params *p);
 void fit_stats_print(FILE *f, const struct fit_stats *stats);
-void fit_data_fit_range_add(struct fit_data *fit_data, const struct roi *range); /* Makes a deep copy */
+int fit_data_fit_range_add(struct fit_data *fit_data, const struct roi *range); /* Makes a deep copy */
 void fit_data_fit_ranges_free(struct fit_data *fit_data);
+int fit_set_roi_from_string(roi *r, const char *str); /* Parses only low and high from "[low:high]". */
 #endif // JABS_FIT_H

--- a/fit.h
+++ b/fit.h
@@ -83,7 +83,7 @@ int fit(struct fit_data *fit_data);
 int fit_function(const gsl_vector *x, void *params, gsl_vector *f);
 void fit_callback(size_t iter, void *params, const gsl_multifit_nlinear_workspace *w);
 fit_params *fit_params_new();
-void fit_params_add_parameter(fit_params *p, double *value);
+int fit_params_add_parameter(fit_params *p, double *value);
 void fit_params_free(fit_params *p);
 void fit_stats_print(FILE *f, const struct fit_stats *stats);
 int fit_data_fit_range_add(struct fit_data *fit_data, const struct roi *range); /* Makes a deep copy */

--- a/generic.c
+++ b/generic.c
@@ -130,6 +130,7 @@ void argv_free(char **argv, int argc) {
         free(argv[i]);
     }
 #else
+    (void) argc;
     free(argv[0]);
 #endif
     free(argv);

--- a/generic.c
+++ b/generic.c
@@ -107,7 +107,9 @@ char **string_to_argv(const char *str, int *argc) { /* Returns allocated array o
         }
     }
     for(i = 0; i < n; i++) { /* We should have our final strings now, let's make deep copies */
+#ifdef ARGV_DEEP_COPY
         out[i] = strdup(out[i]);
+#endif
 #ifdef DEBUG
         fprintf(stderr, "argv[%zu] = %s\n", i, out[i]);
 #endif
@@ -116,14 +118,20 @@ char **string_to_argv(const char *str, int *argc) { /* Returns allocated array o
     if(argc) {
         *argc = n;
     }
+#ifdef ARGV_DEEP_COPY
     free(s);
+#endif
     return out;
 }
 
 void argv_free(char **argv, int argc) {
+#ifdef ARGV_DEEP_COPY
     for(int i = 0; i < argc; i++) {
         free(argv[i]);
     }
+#else
+    free(argv[0]);
+#endif
     free(argv);
 }
 

--- a/generic.h
+++ b/generic.h
@@ -24,5 +24,5 @@ FILE *fopen_file_or_stream(const char *filename, const char *mode); /* opens fil
 void fclose_file_or_stream(FILE *f); /* fclose() if f is not stdout or stderr */
 
 char *strdup_non_null(const char *s); /* if s is NULL, returns NULL, else strdup(s) */
-int asprintf_append(char **ret, const char * restrict format, ...);
+int asprintf_append(char **ret, const char *format, ...);
 #endif //JABS_GENERIC_H

--- a/jabs.c
+++ b/jabs.c
@@ -597,17 +597,17 @@ int fit_params_add(simulation *sim, const sample_model *sm, fit_params *params, 
                 detector *det = sim->det[i_det];
                 assert(det);
                 if(strncmp(token, "calib", 5) == 0) {
-                    fit_params_add_parameter(params, &det->slope); /* TODO: prevent adding already added things */
-                    fit_params_add_parameter(params, &det->offset);
+                    fit_params_add_parameter(params, calibration_get_param_ref(det->calibration, CALIBRATION_PARAM_SLOPE));
+                    fit_params_add_parameter(params, calibration_get_param_ref(det->calibration, CALIBRATION_PARAM_OFFSET));
                     fit_params_add_parameter(params, &det->resolution);
                     jabs_message(MSG_INFO, stderr, "Added fit parameters (slope, offset, resolution) for detector %zu calibration\n", i_det + 1);
                 }
                 if(strcmp(token, "slope") == 0) {
-                    fit_params_add_parameter(params, &det->slope);
+                    fit_params_add_parameter(params, calibration_get_param_ref(det->calibration, CALIBRATION_PARAM_SLOPE));
                     jabs_message(MSG_INFO,  stderr, "Added fit parameters for detector %zu calibration slope\n", i_det + 1);
                 }
                 if(strcmp(token, "offset") == 0) {
-                    fit_params_add_parameter(params, &det->offset);
+                    fit_params_add_parameter(params, calibration_get_param_ref(det->calibration, CALIBRATION_PARAM_OFFSET));
                     jabs_message(MSG_INFO, stderr, "Added fit parameters for detector %zu calibration offset\n", i_det + 1);
                 }
                 if(strncmp(token, "reso", 4) == 0) {

--- a/jabs.c
+++ b/jabs.c
@@ -600,23 +600,23 @@ int fit_params_add(simulation *sim, const sample_model *sm, fit_params *params, 
                     fit_params_add_parameter(params, &det->slope); /* TODO: prevent adding already added things */
                     fit_params_add_parameter(params, &det->offset);
                     fit_params_add_parameter(params, &det->resolution);
-                    jabs_message(MSG_INFO, stderr, "Added fit parameters (slope, offset, resolution) for detector %zu calibration\n", i_det);
+                    jabs_message(MSG_INFO, stderr, "Added fit parameters (slope, offset, resolution) for detector %zu calibration\n", i_det + 1);
                 }
                 if(strcmp(token, "slope") == 0) {
                     fit_params_add_parameter(params, &det->slope);
-                    jabs_message(MSG_INFO,  stderr, "Added fit parameters for detector %zu calibration slope\n", i_det);
+                    jabs_message(MSG_INFO,  stderr, "Added fit parameters for detector %zu calibration slope\n", i_det + 1);
                 }
                 if(strcmp(token, "offset") == 0) {
                     fit_params_add_parameter(params, &det->offset);
-                    jabs_message(MSG_INFO, stderr, "Added fit parameters for detector %zu calibration offset\n", i_det);
+                    jabs_message(MSG_INFO, stderr, "Added fit parameters for detector %zu calibration offset\n", i_det + 1);
                 }
                 if(strncmp(token, "reso", 4) == 0) {
                     fit_params_add_parameter(params, &det->resolution);
-                    jabs_message(MSG_INFO, stderr, "Added fit parameters for detector %zu resolution\n", i_det);
+                    jabs_message(MSG_INFO, stderr, "Added fit parameters for detector %zu resolution\n", i_det + 1);
                 }
                 if(strncmp(token, "solid", 5) == 0) {
                     fit_params_add_parameter(params, &det->solid);
-                    jabs_message(MSG_INFO, stderr, "Added fit parameters for detector %zu solid angle\n", i_det);
+                    jabs_message(MSG_INFO, stderr, "Added fit parameters for detector %zu solid angle\n", i_det + 1);
                 }
             }
             if(strcmp(token, "fluence") == 0) {

--- a/jabs.c
+++ b/jabs.c
@@ -443,38 +443,46 @@ int simulate(const ion *incident, const depth depth_start, sim_workspace *ws, co
     return EXIT_SUCCESS;
 }
 
-int assign_stopping_Z2(jibal_gsto *gsto, const simulation *sim, int Z2) {
+int assign_stopping_Z2(jibal_gsto *gsto, const simulation *sim, int Z2) { /* Assigns stopping and straggling (GSTO) for given Z2. Goes through all possible Z1s (beam and reaction products). */
     int fail = FALSE;
-    if (!jibal_gsto_auto_assign(gsto, sim->beam_isotope->Z, Z2)) { /* This should handle RBS */
-        jabs_message(MSG_ERROR, stderr, "Can not assign stopping or straggling for incident beam (Z = %i) in Z2 = %i.\n", sim->beam_isotope->Z, Z2);
-        fail = TRUE;
-    }
-    if(!jibal_gsto_get_assigned_file(gsto, GSTO_STO_ELE, sim->beam_isotope->Z, Z2)) {
-        jabs_message(MSG_ERROR, stderr, "Could not assign stopping for incident beam (Z = %i) in Z2 = %i.\n", sim->beam_isotope->Z, Z2);
-        fail = TRUE;
-    }
-    if(!jibal_gsto_get_assigned_file(gsto, GSTO_STO_STRAGG, sim->beam_isotope->Z, Z2)) {
-        jabs_message(MSG_ERROR, stderr, "Could not assign straggling for incident beam (Z = %i) in Z2 = %i.\n", sim->beam_isotope->Z, Z2);
+    int Z1 = sim->beam_isotope->Z;
+#ifdef DEBUG
+    fprintf(stderr, "Assigning stopping in Z2 = %i\n", Z2);
+#endif
+    if(assign_stopping_Z1_Z2(gsto, Z1, Z2)) {
+        jabs_message(MSG_ERROR, stderr, "Can not assign stopping or straggling for beam.\n");
         fail = TRUE;
     }
     for(size_t i_reaction = 0; i_reaction < sim->n_reactions; i_reaction++) {
         const reaction *r = sim->reactions[i_reaction];
         if(!r)
             continue;
-        if (!jibal_gsto_auto_assign(gsto, r->product->Z, Z2)) {
-            jabs_message(MSG_ERROR, stderr, "Can not assign stopping for reaction product (Z = %i) in Z2 = %i. Reaction: %s.\n", r->product->Z, Z2, reaction_name(r));
-            fail = TRUE;
+        if(r->product->Z == Z1) {/* Z1 repeats, skip */
+            continue;
         }
-        if(!jibal_gsto_get_assigned_file(gsto, GSTO_STO_ELE, r->product->Z, Z2)) {
-            jabs_message(MSG_ERROR, stderr, "Could not assign stopping for reaction product (Z = %i) in Z2 = %i. Reaction: %s.\n", r->product->Z, Z2, reaction_name(r));
-            fail = TRUE;
-        }
-        if(!jibal_gsto_get_assigned_file(gsto, GSTO_STO_STRAGG, r->product->Z, Z2)) {
-            jabs_message(MSG_ERROR, stderr, "Could not assign straggling for reaction product  (Z = %i) in Z2 = %i. Reaction: %s.\n", r->product->Z, Z2, reaction_name(r));
+        Z1 = r->product->Z;
+        if(assign_stopping_Z1_Z2(gsto, Z1, Z2)) {
+            jabs_message(MSG_ERROR, stderr, "Can not assign stopping or straggling for reaction product. Reaction: %s.\n", reaction_name(r));
             fail = TRUE;
         }
     }
     return fail;
+}
+
+int assign_stopping_Z1_Z2(jibal_gsto *gsto, int Z1, int Z2) {
+    if(!jibal_gsto_auto_assign(gsto, Z1, Z2)) {
+        jabs_message(MSG_ERROR, stderr, "Assign of stopping for Z1 = %i in Z2 = %i fails.\n", Z1, Z2);
+        return EXIT_FAILURE;
+    }
+    if(!jibal_gsto_get_assigned_file(gsto, GSTO_STO_ELE, Z1, Z2)) {
+        jabs_message(MSG_ERROR, stderr, "No electronic stopping assigned for Z1 = %i in Z2 = %i.\n", Z1, Z2);
+        return EXIT_FAILURE;
+    }
+    if(!jibal_gsto_get_assigned_file(gsto, GSTO_STO_STRAGG, Z1, Z2)) {
+        jabs_message(MSG_ERROR, stderr, "No energy loss straggling assigned for Z1 = %i in Z2 = %i.\n", Z1, Z2);
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
 }
 
 int assign_stopping(jibal_gsto *gsto, const simulation *sim) {

--- a/jabs.h
+++ b/jabs.h
@@ -28,6 +28,8 @@ void post_scatter_exit(ion *p, depth depth_start, const sim_workspace *ws, const
 void foil_traverse(ion *p, const sample *foil, sim_workspace *ws);
 int simulate(const ion *incident, depth depth_start, sim_workspace *ws, const sample *sample);
 int assign_stopping(jibal_gsto *gsto, const simulation *sim);
+int assign_stopping_Z2(jibal_gsto *gsto, const simulation *sim, int Z2); /* Assigns stopping and straggling (GSTO) for given Z2. Goes through all possible Z1s (beam and reaction products). */
+int assign_stopping_Z1_Z2(jibal_gsto *gsto, int Z1, int Z2);
 int print_spectra(const char *filename, const sim_workspace *ws, const gsl_histogram *exp);
 int fit_params_add(simulation *sim, const sample_model *sm, fit_params *params, const char *fit_vars); /* fit_vars is a comma separated list of variables to fit */
 void fit_params_clear(fit_params *params);

--- a/main.c
+++ b/main.c
@@ -106,7 +106,10 @@ int main(int argc, char * const *argv) {
     if(cmd_opt->interactive || script_files) {
         if(script_files) {
             for(int i = 0; i < argc; i++) {
-                status = script_process(session, argv[i]);
+                if(script_session_load_script(session, argv[i])) {
+                    return EXIT_FAILURE;
+                }
+                status = script_process(session);
                 if(status != SCRIPT_COMMAND_EOF) {
                     return status;
                 }
@@ -114,7 +117,10 @@ int main(int argc, char * const *argv) {
         }
         if(cmd_opt->interactive) {
             greeting(TRUE);
-            status = script_process(session, NULL);
+            if(script_session_load_script(session, NULL)) {
+                return EXIT_FAILURE;
+            }
+            status = script_process(session);
         }
     } else { /* Non-interactive, pure command line mode. Run a single sim or fit. */
         if(!session->output_filename) {

--- a/main.c
+++ b/main.c
@@ -68,7 +68,7 @@ int main(int argc, char * const *argv) {
     sim->rbs = cmd_opt->rbs;
     sim->erd = cmd_opt->erd;
     session->output_filename = strdup_non_null(cmd_opt->output_filename);
-    roi range = {.low = cmd_opt->fit_low, .high = cmd_opt->fit_high};
+    roi range = {.i_det = 0, .low = cmd_opt->fit_low, .high = cmd_opt->fit_high};
     fit_data_fit_range_add(fit_data, &range); /* We add just this one range (or none) */
     sim_sanity_check(sim);
     if(cmd_opt->exp_filename) {

--- a/main.c
+++ b/main.c
@@ -28,14 +28,16 @@
 #include <jibal.h>
 #include <jibal_cs.h>
 
+#include "defaults.h"
+#include "generic.h"
 #include "options.h"
 #include "sample.h"
 #include "simulation.h"
 #include "spectrum.h"
 #include "fit.h"
 #include "script.h"
-#include "generic.h"
-#include "defaults.h"
+#include "script_session.h"
+#include "script_command.h"
 
 int main(int argc, char * const *argv) {
 #ifdef DEBUG

--- a/message.h
+++ b/message.h
@@ -11,8 +11,8 @@
     See LICENSE.txt for the full license.
 
  */
-#ifndef _JABS_MESSAGE_H_
-#define _JABS_MESSAGE_H_
+#ifndef JABS_MESSAGE_H
+#define JABS_MESSAGE_H
 
 #include <stdio.h>
 

--- a/options.c
+++ b/options.c
@@ -146,10 +146,10 @@ void read_options(const jibal *jibal, simulation *sim, cmdline_options *cmd_opt,
                 cmd_opt->stop_step_exiting = jibal_get_val(jibal->units, UNIT_TYPE_ENERGY, optarg);
                 break;
             case '1':
-                sim->det[0]->slope = jibal_get_val(jibal->units, UNIT_TYPE_ENERGY, optarg);
+                calibration_set_param(sim->det[0]->calibration, CALIBRATION_PARAM_SLOPE, jibal_get_val(jibal->units, UNIT_TYPE_ANY, optarg));
                 break;
             case '2':
-                sim->det[0]->offset = jibal_get_val(jibal->units, UNIT_TYPE_ENERGY, optarg);
+                calibration_set_param(sim->det[0]->calibration, CALIBRATION_PARAM_OFFSET, jibal_get_val(jibal->units, UNIT_TYPE_ANY, optarg));
                 break;
             case 'c':
                 sim->det[0]->compress = atoi(optarg);

--- a/qjabs/CMakeLists.txt
+++ b/qjabs/CMakeLists.txt
@@ -81,6 +81,7 @@ set(PROJECT_SOURCES
         ../script_session.h
         ../script_file.c
         ../script_file.h
+        ../script_generic.h
        main.cpp
        mainwindow.cpp
        mainwindow.h

--- a/qjabs/highlighter.cpp
+++ b/qjabs/highlighter.cpp
@@ -59,6 +59,7 @@
 #include "highlighter.h"
 extern "C" {
 #include <../generic.h>
+#include <../script_command.h>
 }
 
 Highlighter::Highlighter(QTextDocument *parent)
@@ -116,8 +117,11 @@ void Highlighter::highlightArgv(int argc, char **argv) {
     const char *argv_start = argv[0];
     while(argc && cmds) {
         const script_command *c = script_command_find(cmds, argv[0]);
+        //qDebug() << "Parsing" << argv[0] << "first of cmds is" << cmds->name << cmds;
         if(!c) {
-            return;
+            argc--;
+            argv++;
+            continue;
         }
         while(c) { /* Subcommand found */
             size_t arg_len = strlen(argv[0]);
@@ -125,6 +129,8 @@ void Highlighter::highlightArgv(int argc, char **argv) {
                 setFormat(argv[0] - argv_start, arg_len, commandFormat);
             } else if(c->var) {
                 setFormat(argv[0] - argv_start, arg_len, variableFormat);
+            } else if(c->val) {
+                setFormat(argv[0] - argv_start, arg_len, commandFormat);
             }
             if(c->subcommands) {
                 setFormat(argv[0] - argv_start, arg_len, commandFormat);

--- a/qjabs/highlighter.cpp
+++ b/qjabs/highlighter.cpp
@@ -71,9 +71,9 @@ Highlighter::Highlighter(QTextDocument *parent)
     variableFormat.setFontWeight(QFont::StyleItalic);
 }
 
-void Highlighter::setCommands(const script_command *commands)
+void Highlighter::setSession(const script_session *session)
 {
-    Highlighter::commands = commands;
+    Highlighter::session = session;
 }
 
 void Highlighter::highlightBlock(const QString &text)
@@ -94,7 +94,7 @@ void Highlighter::highlightBlock(const QString &text)
         return;
 
     }
-    perkele(argc, argv);
+    highlightArgv(argc, argv);
     argv_free(argv, argc);
 
 
@@ -110,8 +110,8 @@ void Highlighter::highlightBlock(const QString &text)
     setCurrentBlockState(0);
 }
 
-void Highlighter::perkele(int argc, char **argv) {
-    const script_command *cmds = commands;
+void Highlighter::highlightArgv(int argc, char **argv) {
+    const script_command *cmds = session->commands;
     const script_command *c_parent = NULL;
     const char *argv_start = argv[0];
     while(argc && cmds) {

--- a/qjabs/highlighter.h
+++ b/qjabs/highlighter.h
@@ -77,7 +77,8 @@ class Highlighter : public QSyntaxHighlighter
 
 public:
     Highlighter(QTextDocument *parent = nullptr);
-    void addHighLightingRulesFromScriptCommands(const script_command *commands);
+    void setCommands(const script_command *commands);
+    void perkele(int argc, char **argv);
 
 protected:
     void highlightBlock(const QString &text) override;
@@ -89,6 +90,10 @@ private:
         QTextCharFormat format;
     };
     QList<HighlightingRule> highlightingRules;
+    QTextCharFormat singleLineCommentFormat;
+    QTextCharFormat commandFormat;
+    QTextCharFormat variableFormat;
+    const script_command *commands;
 };
 //! [0]
 

--- a/qjabs/highlighter.h
+++ b/qjabs/highlighter.h
@@ -62,7 +62,7 @@
 #include <QTextCharFormat>
 #include <QRegularExpression>
 extern "C" {
-#include "../script_session.h"
+#include "../script_generic.h"
 }
 
 

--- a/qjabs/highlighter.h
+++ b/qjabs/highlighter.h
@@ -61,6 +61,10 @@
 #include <QSyntaxHighlighter>
 #include <QTextCharFormat>
 #include <QRegularExpression>
+extern "C" {
+#include "../script_command.h"
+}
+
 
 QT_BEGIN_NAMESPACE
 class QTextDocument;
@@ -73,6 +77,7 @@ class Highlighter : public QSyntaxHighlighter
 
 public:
     Highlighter(QTextDocument *parent = nullptr);
+    void addHighLightingRulesFromScriptCommands(const script_command *commands);
 
 protected:
     void highlightBlock(const QString &text) override;
@@ -84,9 +89,6 @@ private:
         QTextCharFormat format;
     };
     QList<HighlightingRule> highlightingRules;
-
-    QTextCharFormat commandFormat;
-    QTextCharFormat singleLineCommentFormat;
 };
 //! [0]
 

--- a/qjabs/highlighter.h
+++ b/qjabs/highlighter.h
@@ -62,7 +62,7 @@
 #include <QTextCharFormat>
 #include <QRegularExpression>
 extern "C" {
-#include "../script_command.h"
+#include "../script_session.h"
 }
 
 
@@ -77,8 +77,8 @@ class Highlighter : public QSyntaxHighlighter
 
 public:
     Highlighter(QTextDocument *parent = nullptr);
-    void setCommands(const script_command *commands);
-    void perkele(int argc, char **argv);
+    void setSession(const script_session *session);
+    void highlightArgv(int argc, char **argv);
 
 protected:
     void highlightBlock(const QString &text) override;
@@ -93,7 +93,7 @@ private:
     QTextCharFormat singleLineCommentFormat;
     QTextCharFormat commandFormat;
     QTextCharFormat variableFormat;
-    const script_command *commands;
+    const script_session *session;
 };
 //! [0]
 

--- a/qjabs/main.cpp
+++ b/qjabs/main.cpp
@@ -58,7 +58,7 @@ void jabs_message(jabs_msg_level level, FILE *f, const char * format, ...) {
     if(f == stderr)     {
         char *str_out;
         vasprintf(&str_out, format, argp);
-        mainWindow->addMessage(str_out);
+        mainWindow->addMessage(level, str_out);
         fputs(str_out, stderr);
         free(str_out);
     } else {

--- a/qjabs/mainwindow.cpp
+++ b/qjabs/mainwindow.cpp
@@ -46,6 +46,7 @@ MainWindow::MainWindow(QWidget *parent)
     session = script_session_init(jibal, NULL);
     ui->action_Run->setShortcutContext(Qt::ApplicationShortcut);
     highlighter = new Highlighter(ui->plainTextEdit->document());
+    highlighter->addHighLightingRulesFromScriptCommands(session->commands);
     ui->action_New_File->setShortcut(QKeySequence::New);
     ui->action_Open_File->setShortcut(QKeySequence::Open);
     ui->action_Save_File->setShortcut(QKeySequence::Save);

--- a/qjabs/mainwindow.cpp
+++ b/qjabs/mainwindow.cpp
@@ -157,6 +157,11 @@ void MainWindow::on_action_Run_triggered()
         if(runLine(line) < 0) {
             return; /* or break? */
         }
+        if(session->file_depth > 0) {
+            if(script_process(session) < 0) {
+                return;
+            }
+        }
     }
     plotSession();
 }

--- a/qjabs/mainwindow.cpp
+++ b/qjabs/mainwindow.cpp
@@ -4,6 +4,12 @@
 #include <QDebug>
 #include <QTextStream>
 
+extern "C" {
+#include "script.h"
+#include "script_session.h"
+#include "script_command.h"
+}
+
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)

--- a/qjabs/mainwindow.cpp
+++ b/qjabs/mainwindow.cpp
@@ -46,7 +46,7 @@ MainWindow::MainWindow(QWidget *parent)
     session = script_session_init(jibal, NULL);
     ui->action_Run->setShortcutContext(Qt::ApplicationShortcut);
     highlighter = new Highlighter(ui->plainTextEdit->document());
-    highlighter->setCommands(session->commands);
+    highlighter->setSession(session);
     ui->action_New_File->setShortcut(QKeySequence::New);
     ui->action_Open_File->setShortcut(QKeySequence::Open);
     ui->action_Save_File->setShortcut(QKeySequence::Save);
@@ -91,8 +91,7 @@ void MainWindow::openFile(const QString &filename)
 }
 
 
-int MainWindow::runLine(const QString &line, size_t lineno) {
-    //jabs_message(MSG_INFO, stderr, "jabs> %s\n", qPrintable(line));
+int MainWindow::runLine(const QString &line) {
     int status = script_execute_command(session, qPrintable(line));
     return status;
 }
@@ -135,8 +134,9 @@ void MainWindow::on_action_Run_triggered()
                 continue;
         if(line.at(0) == '#')
             continue;
-        if(runLine(line, lineno))
+        if(runLine(line) < 0) {
             return;
+        }
     }
     plotSession();
 }
@@ -324,7 +324,7 @@ void MainWindow::on_actionAbout_triggered()
 
 void MainWindow::on_commandLineEdit_returnPressed()
 {
-    if(runLine(ui->commandLineEdit->text()) == EXIT_SUCCESS) {
+    if(runLine(ui->commandLineEdit->text()) == SCRIPT_COMMAND_SUCCESS) {
             ui->commandLineEdit->clear();
     }
     plotSession();

--- a/qjabs/mainwindow.cpp
+++ b/qjabs/mainwindow.cpp
@@ -46,7 +46,7 @@ MainWindow::MainWindow(QWidget *parent)
     session = script_session_init(jibal, NULL);
     ui->action_Run->setShortcutContext(Qt::ApplicationShortcut);
     highlighter = new Highlighter(ui->plainTextEdit->document());
-    highlighter->addHighLightingRulesFromScriptCommands(session->commands);
+    highlighter->setCommands(session->commands);
     ui->action_New_File->setShortcut(QKeySequence::New);
     ui->action_Open_File->setShortcut(QKeySequence::Open);
     ui->action_Save_File->setShortcut(QKeySequence::Save);

--- a/qjabs/mainwindow.h
+++ b/qjabs/mainwindow.h
@@ -8,7 +8,7 @@ extern "C" {
 #include <jibal_units.h>
 #include "jabs.h"
 #include "sample.h"
-#include "script.h"
+#include "script_generic.h"
 #include "generic.h"
 #include "message.h"
 #include "defaults.h"

--- a/qjabs/mainwindow.h
+++ b/qjabs/mainwindow.h
@@ -65,7 +65,7 @@ private slots:
 private:
     void updateWindowTitle();
     void setFilename(const QString &filename);
-    int runLine(const QString &line, size_t lineno = 0);
+    int runLine(const QString &line);
     void plotSession();
     Ui::MainWindow *ui;
     struct jibal *jibal;

--- a/qjabs/mainwindow.h
+++ b/qjabs/mainwindow.h
@@ -29,7 +29,7 @@ class MainWindow : public QMainWindow
 
 public:
     MainWindow(QWidget *parent = nullptr);
-    void addMessage(const char *msg);
+    void addMessage(jabs_msg_level level, const char *msg);
     ~MainWindow();
 
 public slots:

--- a/qjabs/mainwindow.ui
+++ b/qjabs/mainwindow.ui
@@ -80,7 +80,7 @@
          </size>
         </property>
        </widget>
-       <widget class="QPlainTextEdit" name="msgPlainTextEdit">
+       <widget class="QTextEdit" name="msgTextEdit">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
           <horstretch>0</horstretch>
@@ -92,9 +92,6 @@
           <width>300</width>
           <height>100</height>
          </size>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
         </property>
        </widget>
        <widget class="QLineEdit" name="commandLineEdit"/>

--- a/script.c
+++ b/script.c
@@ -29,6 +29,12 @@ int script_process(script_session *s) {
         if(status == SCRIPT_COMMAND_EXIT || (status != SCRIPT_COMMAND_SUCCESS && !interactive)) { /* on exit, close all nested script files. When non-interactive, close scripts on error until interactive (or exit). */
             script_file_close(sfile);
             s->file_depth--;
+#ifdef DEBUG
+            fprintf(stderr, "Depth now %zu, status = %s\n", s->file_depth, script_command_status_to_string(status));
+#endif
+            if(status == SCRIPT_COMMAND_EOF) {
+                status = SCRIPT_COMMAND_SUCCESS;
+            }
             continue;
         }
         if(interactive) {

--- a/script.c
+++ b/script.c
@@ -20,10 +20,7 @@
 #include "script_command.h"
 #include "script_file.h"
 
-int script_process(script_session *s, const char *filename) {
-    if(script_session_load_script(s, filename)) {
-        return EXIT_FAILURE;
-    }
+int script_process(script_session *s) {
     static const char *prompt = PROMPT;
     script_command_status status = SCRIPT_COMMAND_SUCCESS;
     while(s->file_depth > 0) {
@@ -51,9 +48,6 @@ int script_process(script_session *s, const char *filename) {
             if(interactive)
                 status = SCRIPT_COMMAND_EXIT;
         }
-    }
-    if(s->files[0]->interactive) {
-        jabs_message(MSG_INFO, stderr, "\nBye!\n");
     }
     fflush(stderr);
     return status;

--- a/script.c
+++ b/script.c
@@ -12,16 +12,13 @@
 
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <jibal_units.h>
-#include "fit.h"
-#include "generic.h"
-#include "spectrum.h"
-#include "script.h"
-#include "jabs.h"
 #include "message.h"
+#include "script.h"
+#include "script_session.h"
+#include "script_command.h"
+#include "script_file.h"
 
 int script_process(script_session *s, const char *filename) {
     if(script_session_load_script(s, filename)) {

--- a/script.c
+++ b/script.c
@@ -46,7 +46,8 @@ int script_process(script_session *s, const char *filename) {
             }
             status = script_execute_command(s, sfile->line);
             if(!interactive && status != SCRIPT_COMMAND_SUCCESS) {
-                jabs_message(MSG_ERROR, stderr, "Error (%i) on line %zu in file \"%s\". Aborting.\n", status, sfile->lineno, sfile->filename);
+                jabs_message(MSG_ERROR, stderr, "Error %i (%s) on line %zu in file \"%s\". Aborting.\n", status,
+                             script_command_status_to_string(status), sfile->lineno, sfile->filename);
             }
         } else {
             status = SCRIPT_COMMAND_EOF;

--- a/script.h
+++ b/script.h
@@ -14,10 +14,7 @@
 
 #ifndef JABS_SCRIPT_H
 #define JABS_SCRIPT_H
-#include <stdio.h>
-#include "jabs.h"
 
-#include "script_command.h"
+#include "script_generic.h"
 int script_process(script_session *s, const char *filename);
-script_command_status script_execute_command(script_session *s, const char *cmd);
 #endif // JABS_SCRIPT_H

--- a/script.h
+++ b/script.h
@@ -16,5 +16,5 @@
 #define JABS_SCRIPT_H
 
 #include "script_generic.h"
-int script_process(script_session *s, const char *filename);
+int script_process(script_session *s);
 #endif // JABS_SCRIPT_H

--- a/script_command.c
+++ b/script_command.c
@@ -385,7 +385,7 @@ script_command_status script_execute_command(script_session *s, const char *cmd)
         return SCRIPT_COMMAND_FAILURE;
     }
     if(argc) {
-        status = script_execute_command_argv(s, script_commands, argc, argv); /* Note that s->file_depth may be altered (e.g. by script_load_script() */
+        status = script_execute_command_argv(s, s->commands, argc, argv); /* Note that s->file_depth may be altered (e.g. by script_load_script() */
     } else {
         status = SCRIPT_COMMAND_SUCCESS; /* Doing nothing successfully */
     }
@@ -1188,9 +1188,9 @@ script_command_status script_help(script_session *s, int argc, char * const *arg
                 }
                 jabs_message(MSG_INFO, stderr, "\n");
             } else if(strcmp(t->name, "commands") == 0) {
-                script_print_commands(stderr, script_commands);
+                script_print_commands(stderr, s->commands);
             } else if(strcmp(t->name, "command_tree") == 0) {
-                script_print_command_tree(stderr, script_commands);
+                script_print_command_tree(stderr, s->commands);
             } else if(strcmp(t->name, "version") == 0) {
                 jabs_message(MSG_INFO, stderr, "%s\n", jabs_version());
             } else if(strcmp(t->name, "set") == 0) {
@@ -1228,7 +1228,7 @@ script_command_status script_help(script_session *s, int argc, char * const *arg
         }
     }
 
-    for(const struct script_command *c = script_commands; c->name != NULL; c++) {
+    for(const struct script_command *c = s->commands; c->name != NULL; c++) {
         if(strcmp(c->name, argv[0]) == 0) {
             if(!found) { /* There wasn't a help topic  */
                 jabs_message(MSG_INFO, stderr, "\"%s\" is a valid command, but no additional help is available!\n\n", c->name);

--- a/script_command.c
+++ b/script_command.c
@@ -209,7 +209,7 @@ script_command_status script_save_bricks(script_session *s, int argc, char * con
 script_command_status script_save_spectra(script_session *s, int argc, char * const *argv) {
     size_t i_det = 0;
     struct fit_data *fit = s->fit;
-    int argc_orig = argc;
+    const int argc_orig = argc;
     if(script_get_detector_number(fit->sim, TRUE, &argc, &argv, &i_det) || argc < 1) {
         jabs_message(MSG_ERROR, stderr, "Usage: save spectra [detector] file\n");
         return SCRIPT_COMMAND_FAILURE;
@@ -248,7 +248,7 @@ script_command_status script_save_sample(script_session *s, int argc, char * con
 script_command_status script_save_detector(script_session *s, int argc, char * const *argv) {
     struct fit_data *fit_data = s->fit;
     size_t i_det = 0;
-    int argc_orig = argc;
+    const int argc_orig = argc;
     if(script_get_detector_number(fit_data->sim, TRUE, &argc, &argv, &i_det) || argc < 1) {
         jabs_message(MSG_ERROR, stderr, "Usage: save detector [detector] file\n");
         return SCRIPT_COMMAND_FAILURE;
@@ -891,22 +891,21 @@ script_command *script_commands_create(struct script_session *s) {
     script_command *c_detector = script_command_new("detector", "Set detector properties.", 0, &script_set_detector);
     c_detector->f_val = &script_set_detector_val;
     script_command_list_add_command(&c_set->subcommands, c_detector);
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("aperture", "Set aperture", 0, &script_set_detector_aperture));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("calibration", "Set calibration", 0, &script_set_detector_calibration));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("column", "", 'c', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("channels", "", 'h', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("compress", "", 'C', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("distance", "", 'd', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("foil", "Set foil", 0, &script_set_detector_foil));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("type", "", 't', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("slope", "", 'S', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("offset", "", 'O', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("resolution", "", 'r', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("solid", "", 's', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("theta", "", 'T', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("length", "", 'l', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("phi", "", 'p', NULL));
-
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("aperture", "Set detector aperture.", 0, &script_set_detector_aperture));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("calibration", "Set calibration.", 0, &script_set_detector_calibration));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("column", "Set column number (for data input).", 'c', NULL));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("channels", "Set number of channels.", 'h', NULL));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("compress", "Set compress (summing of channels).", 'C', NULL));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("distance", "Set detector distance from target.", 'd', NULL));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("foil", "Set detector foil.", 0, &script_set_detector_foil));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("type", "Set detector type.", 't', NULL));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("slope", "Set detector calibration slope.", 'S', NULL));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("offset", "Set detector calibration offset.", 'O', NULL));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("resolution", "Set detector resolution (FWHM).", 'r', NULL));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("solid", "Set detector solid angle.", 's', NULL));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("theta", "Set detector (scattering) angle.", 'T', NULL));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("length", "Set detector length (for ToF).", 'l', NULL));
+    script_command_list_add_command(&c_detector->subcommands, script_command_new("phi", "Set detector azimuth angle, 0 = IBM, 90 deg = Cornell.", 'p', NULL));
 
     script_command_list_add_command(&c_set->subcommands, script_command_new("ion", "Set incident ion (isotope).", 0, &script_set_ion));
     script_command_list_add_command(&c_set->subcommands, script_command_new("sample", "Set sample.", 0, &script_set_sample));
@@ -924,10 +923,10 @@ script_command *script_commands_create(struct script_session *s) {
             {JIBAL_CONFIG_VAR_STRING, "output",               &s->output_filename,                 NULL},
             {JIBAL_CONFIG_VAR_BOOL,   "erd",                  &sim->erd,                           NULL},
             {JIBAL_CONFIG_VAR_BOOL,   "rbs",                  &sim->rbs,                           NULL},
-            {JIBAL_CONFIG_VAR_SIZE,   "fit_maxiter",          &fit->n_iters_max,                   NULL},
-            {JIBAL_CONFIG_VAR_DOUBLE, "fit_xtol",             &fit->xtol,                          NULL},
-            {JIBAL_CONFIG_VAR_DOUBLE, "fit_gtol",             &fit->gtol,                          NULL},
-            {JIBAL_CONFIG_VAR_DOUBLE, "fit_ftol",             &fit->ftol,                          NULL},
+            {JIBAL_CONFIG_VAR_SIZE,   "maxiter",              &fit->n_iters_max,                   NULL},
+            {JIBAL_CONFIG_VAR_DOUBLE, "xtolerance",           &fit->xtol,                          NULL},
+            {JIBAL_CONFIG_VAR_DOUBLE, "gtolerance",           &fit->gtol,                          NULL},
+            {JIBAL_CONFIG_VAR_DOUBLE, "ftolerance",           &fit->ftol,                          NULL},
             {JIBAL_CONFIG_VAR_BOOL,   "ds",                   &sim->params.ds,                     NULL},
             {JIBAL_CONFIG_VAR_BOOL,   "rk4",                  &sim->params.rk4,                    NULL},
             {JIBAL_CONFIG_VAR_UNIT,   "stop_step_incident",   &sim->params.stop_step_incident,     NULL},
@@ -936,7 +935,7 @@ script_command *script_commands_create(struct script_session *s) {
             {JIBAL_CONFIG_VAR_BOOL,   "nucl_stop_accurate",   &sim->params.nucl_stop_accurate,     NULL},
             {JIBAL_CONFIG_VAR_BOOL,   "mean_conc_and_energy", &sim->params.mean_conc_and_energy,   NULL},
             {JIBAL_CONFIG_VAR_BOOL,   "geostragg",            &sim->params.geostragg,              NULL},
-            {JIBAL_CONFIG_VAR_NONE, NULL, NULL,                                                      NULL}
+            {JIBAL_CONFIG_VAR_NONE,   NULL,                   NULL,                                NULL}
     };
     c = script_command_list_from_vars_array(vars, 0);
     script_command_list_add_command(&c_set->subcommands, c);
@@ -974,7 +973,11 @@ script_command *script_commands_create(struct script_session *s) {
     c = script_command_new("add", "Add something.", 0, NULL);
     script_command_list_add_command(&head, c);
     script_command_list_add_command(&c->subcommands, script_command_new("detector", "Add a detector.", 0, &script_add_detector));
-    script_command_list_add_command(&c->subcommands, script_command_new("fit_range", "Add a fit range", 0, &script_add_fit_range));
+
+    script_command *c_add_fit =  script_command_new("fit", "Add something related to fit.", 0, NULL);
+    script_command_list_add_command(&c->subcommands, c_add_fit);
+    script_command_list_add_command(&c_add_fit->subcommands, script_command_new("range", "Add a fit range", 0, &script_add_fit_range));
+
     script_command_list_add_command(&c->subcommands, script_command_new("reaction", "Add a reaction.", 0, &script_add_reaction));
     script_command_list_add_command(&c->subcommands, script_command_new("reactions", "Add reactions (of some type).", 0, &script_add_reactions));
 
@@ -1076,7 +1079,10 @@ script_command_status script_load_script(script_session *s, int argc, char * con
         jabs_message(MSG_ERROR, stderr, "Usage: load script [file]\n");
         return SCRIPT_COMMAND_FAILURE;
     }
-    return script_session_load_script(s, argv[0]);
+    if(script_session_load_script(s, argv[0])) {
+        return SCRIPT_COMMAND_FAILURE;
+    }
+    return 1;
 }
 
 script_command_status script_load_sample(script_session *s, int argc, char * const *argv) {
@@ -1254,7 +1260,7 @@ script_command_status script_show_fit(script_session *s, int argc, char * const 
 script_command_status script_show_detector(script_session *s, int argc, char * const *argv) {
     struct fit_data *fit = s->fit;
     size_t i_det = 0;
-    int argc_orig = argc;
+    const int argc_orig = argc;
     if(script_get_detector_number(fit->sim, TRUE, &argc, &argv, &i_det)) {
         return SCRIPT_COMMAND_FAILURE;
     }
@@ -1292,7 +1298,7 @@ script_command_status script_set_ion(script_session *s, int argc, char * const *
 
 script_command_status script_set_aperture(script_session *s, int argc, char * const *argv) {
     struct fit_data *fit = s->fit;
-    int argc_orig = argc;
+    const int argc_orig = argc;
     if(argc < 1) {
         jabs_message(MSG_ERROR, stderr, "Usage: set aperture (type) [width|height|diameter (value)] ...\n");
         return SCRIPT_COMMAND_FAILURE;
@@ -1315,7 +1321,7 @@ script_command_status script_set_aperture(script_session *s, int argc, char * co
 script_command_status script_set_detector(script_session *s, int argc, char *const *argv) {
     struct fit_data *fit = s->fit;
     size_t i_det = 0;
-    int argc_orig = argc;
+    const int argc_orig = argc;
     if(script_get_detector_number(fit->sim, TRUE, &argc, &argv, &i_det)) {
         return SCRIPT_COMMAND_FAILURE;
     }
@@ -1327,7 +1333,7 @@ script_command_status script_set_detector(script_session *s, int argc, char *con
 }
 
 script_command_status script_set_detector_aperture(struct script_session *s, int argc, char * const *argv) {
-    int argc_orig = argc;
+    const int argc_orig = argc;
     detector *det = sim_det(s->fit->sim, s->i_det_active);
     if(!det) {
         jabs_message(MSG_ERROR, stderr, "No detector.\n"); /* TODO: prettify */
@@ -1338,21 +1344,24 @@ script_command_status script_set_detector_aperture(struct script_session *s, int
     return argc_orig - argc;
 }
 
-script_command_status script_set_detector_calibration(struct script_session *s, int argc, char * const *argv) {
+script_command_status script_set_detector_calibration(struct script_session *s, int argc, char *const *argv) {
+    (void) s;
+    (void) argc;
+    (void) argv;
     jabs_message(MSG_ERROR, stderr, "Setting calibration not implemented, use slope and offset.");
     return SCRIPT_COMMAND_FAILURE;
 }
 
-script_command_status script_set_detector_foil(struct script_session *s, int argc, char * const *argv) {
-        int argc_orig = argc;
-        detector *det = sim_det(s->fit->sim, s->i_det_active);
-        if(!det) {
-            jabs_message(MSG_ERROR, stderr, "No detector.\n"); /* TODO: prettify */
-        }
-        if(detector_foil_set_from_argv(s->jibal, det, &argc, &argv)) {
-            return SCRIPT_COMMAND_FAILURE;
-        }
-        return argc_orig - argc;
+script_command_status script_set_detector_foil(struct script_session *s, int argc, char *const *argv) {
+    const int argc_orig = argc;
+    detector *det = sim_det(s->fit->sim, s->i_det_active);
+    if(!det) {
+        jabs_message(MSG_ERROR, stderr, "No detector.\n"); /* TODO: prettify */
+    }
+    if(detector_foil_set_from_argv(s->jibal, det, &argc, &argv)) {
+        return SCRIPT_COMMAND_FAILURE;
+    }
+    return argc_orig - argc;
 }
 
 script_command_status script_set_sample(script_session *s, int argc, char * const *argv) {
@@ -1361,7 +1370,7 @@ script_command_status script_set_sample(script_session *s, int argc, char * cons
         jabs_message(MSG_ERROR, stderr, "Usage: set sample [sample]\nExample: set sample TiO2 1000tfu Si 10000tfu\n");
         return SCRIPT_COMMAND_FAILURE;
     }
-    int argc_orig = argc;
+    const int argc_orig = argc;
     sample_model *sm_new = sample_model_from_argv(fit->jibal, &argc, &argv);
     int argc_consumed = argc_orig - argc;
     sample_model_free(fit->sm);
@@ -1380,7 +1389,7 @@ script_command_status script_add_reaction(script_session *s, int argc, char * co
         jabs_message(MSG_ERROR, stderr, "Usage: add reaction TYPE isotope\n");
         return SCRIPT_COMMAND_FAILURE;
     }
-    int argc_orig = argc;
+    const int argc_orig = argc;
     reaction *r = reaction_make_from_argv(fit->jibal, fit->sim->beam_isotope, &argc, &argv);
     int argc_consumed = argc_orig - argc;
     if(!r) {
@@ -1419,7 +1428,17 @@ script_command_status script_add_reactions(script_session *s, int argc, char * c
     if(fit->sim->rbs) {
         sim_reactions_add_auto(fit->sim, fit->sm, REACTION_RBS, sim_cs(fit->sim, REACTION_RBS)); /* TODO: loop over all detectors and add reactions that are possible (one reaction for all detectors) */
     }
-    if(fit->sim->erd) {
+
+    int forward_angles = FALSE;
+    for(size_t i_det = 0; i_det < fit->sim->n_det; i_det++) {
+        const detector *det = sim_det(fit->sim, i_det);
+        if(det->theta < C_PI_2) {
+            forward_angles = TRUE;
+            break;
+        }
+    }
+
+    if(fit->sim->erd && (forward_angles || fit->sim->params.ds)) { /* ERD can be disabled, but otherwise we'll turn the reactions on only if necessary. */
         sim_reactions_add_auto(fit->sim, fit->sm, REACTION_ERD, sim_cs(fit->sim, REACTION_ERD));
     }
     return 0;
@@ -1440,26 +1459,33 @@ script_command_status script_add_detector(script_session *s, int argc, char * co
 
 script_command_status script_add_fit_range(script_session *s, int argc, char * const *argv) {
     struct fit_data *fit = s->fit;
-    roi range = {.i_det = 0};
-    if(argc == 3) { /* Three arguments, first is the detector number */ /* TODO: we can't rely on fixed number of arguments! */
-        range.i_det = strtoul(argv[0], NULL, 10);
-        if(range.i_det == 0 || range.i_det > fit->sim->n_det) {
-            jabs_message(MSG_ERROR, stderr, "Detector number %zu is not valid (n_det = %zu).\n", range.i_det, fit->sim->n_det);
+    size_t i_det = 0;
+    const int argc_orig = argc;
+    script_get_detector_number(fit->sim, TRUE, &argc, &argv, &i_det);
+    int n_ranges = 0;
+    if(argc < 1) {
+        jabs_message(MSG_ERROR, stderr, "Usage: add fit_range {detector} <range> {<range> <range> ...}\nExample: add fit_range 1 [400:900] [980:1200]\n");
+        return SCRIPT_COMMAND_FAILURE;
+    }
+    while(argc > 0) {
+        roi r = {.i_det = i_det};
+        if(fit_set_roi_from_string(&r,argv[0])) {
+            if(n_ranges == 0) {
+                jabs_message(MSG_ERROR, stderr, "No ranges added! Failed on parsing \"%s\".\n", argv[0]);
+                return SCRIPT_COMMAND_FAILURE;
+            } else {
+                break;
+            }
+        }
+        if(fit_data_fit_range_add(fit, &r)) {
+            jabs_message(MSG_ERROR, stderr, "Range not valid! Failed on parsing \"%s\".\n", argv[0]);
             return SCRIPT_COMMAND_FAILURE;
         }
-        range.i_det--;
+        n_ranges++;
         argc--;
         argv++;
     }
-    if(argc == 2) {
-        range.low = strtoul(argv[0], NULL, 10);
-        range.high = strtoul(argv[1], NULL, 10);
-    } else {
-        jabs_message(MSG_ERROR, stderr, "Usage: add fit_range [detector] low high\n");
-        return -1;
-    }
-    fit_data_fit_range_add(fit, &range);
-    return argc; /* TODO: we can't rely on fixed number of arguments! */
+    return argc_orig - argc;
 }
 
 script_command_status script_help(script_session *s, int argc, char * const *argv) {

--- a/script_command.c
+++ b/script_command.c
@@ -368,7 +368,7 @@ script_command_status script_set_var(struct script_session *s, jibal_config_var 
         return SCRIPT_COMMAND_FAILURE;
     }
     jibal_config_var_set(s->jibal->units, var, argv[0], NULL);
-    return SCRIPT_COMMAND_SUCCESS;
+    return 1; /* Number of arguments */
 }
 
 script_command_status script_set_boolean(script_session *s, const char *variable, int value) {
@@ -761,65 +761,48 @@ script_command *script_commands_create(struct script_session *s) {
     script_command_list_add_command(&c_show->subcommands, script_command_new("variables" , "Show variables.", 0, &script_show_variables));
 
     script_command_list_add_command(&head, script_command_new("exit", "Exit.", 0, &script_exit));
-#if 0
-    static const struct script_command script_save_commands[] = {
-            {"bricks",   &script_save_bricks,   "Save bricks.",   NULL, NULL, 0},
-            {"detector", &script_save_detector, "Save detector.", NULL, NULL, 0},
-            {"sample",   &script_save_sample,   "Save sample.",   NULL, NULL, 0},
-            {"spectra",  &script_save_spectra,  "Save spectra.",  NULL, NULL, 0},
-            {NULL, NULL, NULL,                                    NULL, NULL, 0}
-    };
 
-    static const struct script_command script_add_commands[] = {
-            {"detector",  &script_add_detector,  "Add a detector.",               NULL, NULL, 0},
-            {"fit_range", &script_add_fit_range, "Add a fit range",               NULL, NULL, 0},
-            {"reaction",  &script_add_reaction,  "Add a reaction.",               NULL, NULL, 0},
-            {"reactions", &script_add_reactions, "Add reactions (of some type).", NULL, NULL, 0},
-            {NULL, NULL, NULL,                                                    NULL, NULL, 0}
-    };
+    c = script_command_new("save", "Save something.", 0, NULL);
+    script_command_list_add_command(&head, c);
+    script_command_list_add_command(&c->subcommands, script_command_new("bricks", "Save bricks.", 0, &script_save_bricks));
+    script_command_list_add_command(&c->subcommands, script_command_new("detector", "Save detector.", 0, &script_save_detector));
+    script_command_list_add_command(&c->subcommands, script_command_new("sample", "Save sample.", 0, &script_save_sample));
+    script_command_list_add_command(&c->subcommands, script_command_new("spectra", "Save spectra.", 0, &script_save_spectra));
 
-    static const struct script_command script_show_commands[] = {
-            {"detector",   &script_show_detector,   "Show detector.",   NULL, NULL, 0},
-            {"fit",        &script_show_fit,        "Show fit.",        NULL, NULL, 0},
-            {"reactions",  &script_show_reactions,  "Show reactions,",  NULL, NULL, 0},
-            {"sample",     &script_show_sample,     "Show sample",      NULL, NULL, 0},
-            {"simulation", &script_show_simulation, "Show simulation.", NULL, NULL, 0},
-            {"variables",  &script_show_variables,  "Show variables.",  NULL, NULL, 0},
-            {NULL, NULL, NULL,                                          NULL, NULL, 0},
-    };
+    c = script_command_new("add", "Add something.", 0, NULL);
+    script_command_list_add_command(&head, c);
+    script_command_list_add_command(&c->subcommands, script_command_new("detector", "Add a detector.", 0, &script_add_detector));
+    script_command_list_add_command(&c->subcommands, script_command_new("fit_range", "Add a fit range", 0, &script_add_fit_range));
+    script_command_list_add_command(&c->subcommands, script_command_new("reaction", "Add a reaction.", 0, &script_add_reaction));
+    script_command_list_add_command(&c->subcommands, script_command_new("reactions", "Add reactions (of some type).", 0, &script_add_reactions));
 
-    static const struct script_command script_remove_commands[] = {
-            {"reaction", &script_remove_reaction, "Remove reaction.", NULL, NULL, 0},
-            {NULL, NULL, NULL,                                        NULL, NULL, 0},
-    };
+    c = script_command_new("remove", "Remove something.", 0, NULL);
+    script_command_list_add_command(&head, c);
+    script_command_list_add_command(&c->subcommands, script_command_new("reaction", "Remove reaction.", 0, &script_remove_reaction));
 
-    static const struct script_command script_reset_commands[] = {
-            {"detectors",    &script_reset_detectors,    "Reset detectors.",            NULL, NULL, 0},
-            {"experimental", &script_reset_experimental, "Reset experimental spectra.", NULL, NULL, 0},
-            {"fit_ranges",   &script_reset_fit_ranges,   "Reset fit ranges.",           NULL, NULL, 0},
-            {"reactions",    &script_reset_reactions,    "Reset reactions.",            NULL, NULL, 0},
-            {"sample",       &script_reset_sample,       "Reset sample.",               NULL, NULL, 0},
-            {NULL, NULL, NULL,                                                          NULL, NULL, 0},
-    };
+    c = script_command_new("reset", "Reset something (or everything).", 0, NULL);
+    script_command_list_add_command(&head, c);
+    script_command_list_add_command(&c->subcommands, script_command_new("detectors", "Reset detectors.", 0, &script_reset_detectors));
+    script_command_list_add_command(&c->subcommands, script_command_new("experimental", "Reset experimental spectra.", 0, &script_reset_experimental));
+    script_command_list_add_command(&c->subcommands, script_command_new("fit_ranges", "Reset fit ranges.", 0, &script_reset_fit_ranges));
+    script_command_list_add_command(&c->subcommands, script_command_new("reactions", "Reset reactions.", 0, &script_reset_reactions));
+    script_command_list_add_command(&c->subcommands, script_command_new("sample", "Reset sample.", 0, &script_reset_sample));
 
-    static const struct script_command script_commands[] = {
-            {"add",    NULL,               "Add things.",                 script_add_commands,    NULL, 0}, // done
-            {"disable",  &script_disable,  "Set boolean variable to false.",              NULL,   NULL, 0},
-            {"enable",   &script_enable,   "Set boolean variable to true.",               NULL,   NULL, 0},
-            {"exit",     &script_exit,     "Exit.",                                       NULL,   NULL, 0},  // done
-            {"fit",      &script_fit,      "Do a fit.",                                   NULL,   NULL, 0},
-            {"save",   NULL,               "Save something.",             script_save_commands,   NULL, 0},
-            {"set",    NULL,               "Set variables.",              script_set_commands,    NULL, 0},
-            {"show",   NULL,               "Show information on things.", script_show_commands,   NULL, 0},  // done
-            {"help",     &script_help,     "Print help.",                                 NULL,   NULL, 0},
-            {"load",   NULL,               "Load something.",             script_load_commands,   NULL, 0}, // done
-            {"remove", NULL,               "Remove something",            script_remove_commands, NULL, 0},
-            {"reset",    &script_reset,    "Reset something.",            script_reset_commands,  NULL, 0},
-            {"roi",      &script_roi,      "Show information from a region of interest.", NULL,   NULL, 0},
-            {"simulate", &script_simulate, "Run a simulation.",                           NULL,   NULL, 0},
-            {NULL,     NULL, NULL,                                                        NULL,   NULL, 0}
-    };
-#endif
+    c = script_command_new("fit", "Do a fit.", 0, script_fit);
+    script_command_list_add_command(&head, c);
+
+    c = script_command_new("enable", "Set boolean variable to true.", 0, script_enable);
+    script_command_list_add_command(&head, c);
+
+    c = script_command_new("disable", "Set boolean variable to false.", 0, script_disable);
+    script_command_list_add_command(&head, c);
+
+    c = script_command_new("roi", "Show information from a region of interest.", 0, script_roi);
+    script_command_list_add_command(&head, c);
+
+    c = script_command_new("simulate", "Run a simulation.", 0, script_simulate);
+    script_command_list_add_command(&head, c);
+
     return head;
 }
 
@@ -883,7 +866,7 @@ void script_print_command_tree(FILE *f, const struct script_command *commands) {
 script_command_status script_load_script(script_session *s, int argc, char * const *argv) {
     if(argc < 1) {
         jabs_message(MSG_ERROR, stderr, "Usage: load script [file]\n");
-        return EXIT_FAILURE;
+        return SCRIPT_COMMAND_FAILURE;
     }
     return script_session_load_script(s, argv[0]);
 }
@@ -892,7 +875,7 @@ script_command_status script_load_sample(script_session *s, int argc, char * con
     struct fit_data *fit = s->fit;
     if(argc < 1) {
         jabs_message(MSG_ERROR, stderr, "Usage: load sample [file]\n");
-        return EXIT_FAILURE;
+        return SCRIPT_COMMAND_FAILURE;
     }
     sample_model *sm = sample_model_from_file(fit->jibal, argv[1]);
     if(!sm) {
@@ -940,7 +923,7 @@ script_command_status script_load_experimental(script_session *s, int argc, char
         gsl_histogram_free(fit->exp[i_det]);
     }
     fit->exp[i_det] = h;
-    return EXIT_SUCCESS;
+    return 1; /* Number of arguments */
 }
 
 script_command_status script_load_reaction(script_session *s, int argc, char * const *argv) {
@@ -949,14 +932,18 @@ script_command_status script_load_reaction(script_session *s, int argc, char * c
         jabs_message(MSG_ERROR, stderr, "Usage: load reaction [file]\n");
         return SCRIPT_COMMAND_FAILURE;
     }
-    return sim_reactions_add_r33(fit->sim, fit->jibal->isotopes, argv[0]);
+    if(sim_reactions_add_r33(fit->sim, fit->jibal->isotopes, argv[0])) {
+        return SCRIPT_COMMAND_FAILURE;
+    } else {
+        return 1;
+    }
 }
 
 script_command_status script_reset_reactions(script_session *s, int argc, char * const *argv) {
     (void) argc;
     (void) argv;
     sim_reactions_free(s->fit->sim);
-    return SCRIPT_COMMAND_SUCCESS;
+    return 0;
 }
 
 script_command_status script_reset_detectors(script_session *s, int argc, char * const *argv) {
@@ -966,14 +953,14 @@ script_command_status script_reset_detectors(script_session *s, int argc, char *
         detector_free(sim_det(s->fit->sim, i_det));
     }
     s->fit->sim->n_det = 0;
-    return SCRIPT_COMMAND_SUCCESS;
+    return 0;
 }
 
 script_command_status script_reset_fit_ranges(script_session *s, int argc, char * const *argv) {
     (void) argc;
     (void) argv;
     fit_data_fit_ranges_free(s->fit);
-    return SCRIPT_COMMAND_SUCCESS;
+    return 0;
 }
 
 script_command_status script_reset_sample(script_session *s, int argc, char * const *argv) {
@@ -982,7 +969,7 @@ script_command_status script_reset_sample(script_session *s, int argc, char * co
     struct fit_data *fit = s->fit;
     sample_model_free(fit->sm);
     fit->sm = NULL;
-    return SCRIPT_COMMAND_SUCCESS;
+    return 0;
 }
 
 script_command_status script_reset_experimental(script_session *s, int argc, char * const *argv) {
@@ -991,7 +978,7 @@ script_command_status script_reset_experimental(script_session *s, int argc, cha
     struct fit_data *fit = s->fit;
     fit_data_exp_free(s->fit);
     fit->exp = calloc(fit->sim->n_det, sizeof(gsl_histogram *));
-    return SCRIPT_COMMAND_SUCCESS;
+    return 0;
 }
 
 script_command_status script_reset(script_session *s, int argc, char * const *argv) {
@@ -1019,7 +1006,7 @@ script_command_status script_reset(script_session *s, int argc, char * const *ar
     fit->exp = calloc(fit->sim->n_det, sizeof(gsl_histogram *));
     jibal_gsto_assign_clear_all(fit->jibal->gsto);
     script_session_reset_vars(s);
-    return SCRIPT_COMMAND_SUCCESS;
+    return 0;
 }
 
 script_command_status script_show_sample(script_session *s, int argc, char * const *argv) {
@@ -1028,14 +1015,18 @@ script_command_status script_show_sample(script_session *s, int argc, char * con
     struct fit_data *fit = s->fit;
     if(!fit->sm) {
         jabs_message(MSG_WARNING, stderr, "No sample has been set.\n");
-        return SCRIPT_COMMAND_SUCCESS;
+        return 0;
     } else {
 #ifdef DEBUG
         char *sample_str = sample_model_to_string(fit->sm);
         fprintf(stderr, "Sample: %s\n", sample_str);
         free(sample_str);
 #endif
-        return sample_model_print(NULL, fit->sm);
+        if(sample_model_print(NULL, fit->sm)) {
+            return SCRIPT_COMMAND_FAILURE;
+        } else {
+            return 0;
+        }
     }
 }
 
@@ -1043,22 +1034,23 @@ script_command_status script_show_simulation(script_session *s, int argc, char *
     (void) argc;
     (void) argv;
     simulation_print(stderr, s->fit->sim);
-    return SCRIPT_COMMAND_SUCCESS;
+    return 0;
 }
 script_command_status script_show_fit(script_session *s, int argc, char * const *argv) {
     (void) argc;
     (void) argv;
     fit_data_print(stderr, s->fit);
-    return SCRIPT_COMMAND_SUCCESS;
+    return 0;
 }
 script_command_status script_show_detector(script_session *s, int argc, char * const *argv) {
     struct fit_data *fit = s->fit;
     size_t i_det = 0;
+    int argc_orig = argc;
     if(script_get_detector_number(fit->sim, TRUE, &argc, &argv, &i_det)) {
         return SCRIPT_COMMAND_FAILURE;
     }
     detector_print(NULL, fit->sim->det[i_det]);
-    return SCRIPT_COMMAND_SUCCESS;
+    return argc_orig - argc; /* Number of arguments */
 }
 
 script_command_status script_show_reactions(script_session *s, int argc, char * const *argv) {
@@ -1069,7 +1061,7 @@ script_command_status script_show_reactions(script_session *s, int argc, char * 
         jabs_message(MSG_INFO, stderr, "No reactions.\n");
     }
     reactions_print(stderr, fit->sim->reactions, fit->sim->n_reactions);
-    return SCRIPT_COMMAND_SUCCESS;
+    return 0;
 }
 
 script_command_status script_show_variables(script_session *s, int argc, char *const *argv) {
@@ -1109,7 +1101,7 @@ script_command_status script_show_variables(script_session *s, int argc, char *c
                 break;
         }
     }
-    return SCRIPT_COMMAND_SUCCESS;
+    return 0;
 }
 
 script_command_status script_set_ion(script_session *s, int argc, char * const *argv) {
@@ -1149,11 +1141,12 @@ script_command_status script_set_aperture(script_session *s, int argc, char * co
 
 script_command_status script_set_beam(script_session *s, int argc, char * const *argv) {
     struct fit_data *fit = s->fit;
+    int argc_consumed = 0;
     if(argc < 1) {
         jabs_message(MSG_ERROR, stderr, "Usage: set beam energy|fluence|ion (value)...\n");
         return SCRIPT_COMMAND_FAILURE;
     }
-    while(argc >= 2) {
+    while(argc >= 2) { /* TODO: replace with something */
         if(strcmp(argv[0], "energy") == 0) {
             fit->sim->beam_E = jibal_get_val(fit->jibal->units, UNIT_TYPE_ENERGY, argv[1]);
         } else if(strcmp(argv[0], "energy_broad") == 0) {
@@ -1167,15 +1160,14 @@ script_command_status script_set_beam(script_session *s, int argc, char * const 
                 return SCRIPT_COMMAND_FAILURE;
             }
             fit->sim->beam_isotope = isotope;
+        } else {
+            break;
         }
         argc -= 2;
         argv += 2;
+        argc_consumed += 2;
     }
-    if(argc) {
-        jabs_message(MSG_ERROR, stderr, "Unexpected extra arguments (%i), starting with %s\n", argc, argv[0]);
-        return SCRIPT_COMMAND_FAILURE;
-    }
-    return SCRIPT_COMMAND_SUCCESS;
+    return argc_consumed;
 }
 
 #if 0
@@ -1246,19 +1238,16 @@ script_command_status script_set_sample(script_session *s, int argc, char * cons
         jabs_message(MSG_ERROR, stderr, "Usage: set sample [sample]\nExample: set sample TiO2 1000tfu Si 10000tfu\n");
         return SCRIPT_COMMAND_FAILURE;
     }
+    int argc_orig = argc;
     sample_model *sm_new = sample_model_from_argv(fit->jibal, &argc, &argv);
-    if(argc != 0) {
-        jabs_message(MSG_ERROR, stderr, "Not all arguments were parsed correctly (starting from \"%s\")! Sample not set.\n", argv[0]);
-        sample_model_free(sm_new);
-        return SCRIPT_COMMAND_FAILURE;
-    }
+    int argc_consumed = argc_orig - argc;
     sample_model_free(fit->sm);
     fit->sm = sm_new;
     if(s->fit->sim->n_reactions > 0) {
         jabs_message(MSG_WARNING, stderr, "Reactions were reset automatically, since the sample was changed.\n");
         sim_reactions_free(fit->sim);
     }
-    return SCRIPT_COMMAND_SUCCESS;
+    return argc_consumed;
 }
 
 script_command_status script_set_variable(script_session *s, int argc, char * const *argv) {
@@ -1273,7 +1262,11 @@ script_command_status script_set_variable(script_session *s, int argc, char * co
                 jabs_message(MSG_ERROR, stderr, "Usage: set variable %s [value]\n", var->name);
                 return SCRIPT_COMMAND_FAILURE;
             }
-            return jibal_config_var_set(s->cf->units, var, argv[1], s->cf->filename);
+            if(jibal_config_var_set(s->cf->units, var, argv[1], s->cf->filename)) {
+                return SCRIPT_COMMAND_FAILURE;
+            } else {
+                return 2; /* Number of arguments consumed */
+            }
         }
     }
     return SCRIPT_COMMAND_NOT_FOUND;
@@ -1286,14 +1279,11 @@ script_command_status script_add_reaction(script_session *s, int argc, char * co
         jabs_message(MSG_ERROR, stderr, "Usage: add reaction TYPE isotope\n");
         return SCRIPT_COMMAND_FAILURE;
     }
+    int argc_orig = argc;
     reaction *r = reaction_make_from_argv(fit->jibal, fit->sim->beam_isotope, &argc, &argv);
+    int argc_consumed = argc_orig - argc;
     if(!r) {
         jabs_message(MSG_ERROR, stderr, "Could not make a reaction based on given description.\n");
-        return SCRIPT_COMMAND_FAILURE;
-    }
-    if(argc != 0) {
-        jabs_message(MSG_ERROR, stderr, "Unexpected extra arguments (%i), starting with %s\n", argc, argv[0]);
-        reaction_free(r);
         return SCRIPT_COMMAND_FAILURE;
     }
     if(r->cs == JIBAL_CS_NONE) {
@@ -1302,7 +1292,11 @@ script_command_status script_add_reaction(script_session *s, int argc, char * co
         jabs_message(MSG_VERBOSE, stderr, "Reaction cross section not given or not valid, assuming default for %s: %s.\n",
                      reaction_name(r), jibal_cs_types[cs].s);
     }
-    return sim_reactions_add_reaction(fit->sim, r);
+    if(sim_reactions_add_reaction(fit->sim, r)) {
+        return SCRIPT_COMMAND_FAILURE;
+    } else {
+        return argc_consumed;
+    }
 }
 script_command_status script_add_reactions(script_session *s, int argc, char * const *argv) {
     struct fit_data *fit = s->fit;
@@ -1319,7 +1313,7 @@ script_command_status script_add_reactions(script_session *s, int argc, char * c
             jabs_message(MSG_ERROR, stderr, "What is %s anyways? Did you mean \"RBS\" or \"ERD\"?\n", argv[0]);
             return SCRIPT_COMMAND_FAILURE;
         }
-        return SCRIPT_COMMAND_SUCCESS;
+        return 1;
     }
     if(fit->sim->rbs) {
         sim_reactions_add_auto(fit->sim, fit->sm, REACTION_RBS, sim_cs(fit->sim, REACTION_RBS)); /* TODO: loop over all detectors and add reactions that are possible (one reaction for all detectors) */
@@ -1327,7 +1321,7 @@ script_command_status script_add_reactions(script_session *s, int argc, char * c
     if(fit->sim->erd) {
         sim_reactions_add_auto(fit->sim, fit->sm, REACTION_ERD, sim_cs(fit->sim, REACTION_ERD));
     }
-    return SCRIPT_COMMAND_SUCCESS;
+    return 0;
 }
 
 script_command_status script_add_detector(script_session *s, int argc, char * const *argv) {
@@ -1336,13 +1330,17 @@ script_command_status script_add_detector(script_session *s, int argc, char * co
         jabs_message(MSG_ERROR,  stderr,"Usage: add detector filename\n", argv[0]);
         return SCRIPT_COMMAND_FAILURE;
     }
-    return fit_data_add_det(fit, detector_from_file(fit->jibal, argv[0])); /* Adds a new detector (and space for experimental spectrum) */
+    if(fit_data_add_det(fit, detector_from_file(fit->jibal, argv[0]))) { /* Adds a new detector (and space for experimental spectrum) */
+        return SCRIPT_COMMAND_FAILURE;
+    } else {
+        return 1;
+    }
 }
 
 script_command_status script_add_fit_range(script_session *s, int argc, char * const *argv) {
     struct fit_data *fit = s->fit;
     roi range = {.i_det = 0};
-    if(argc == 3) { /* Three arguments, first is the detector number */
+    if(argc == 3) { /* Three arguments, first is the detector number */ /* TODO: we can't rely on fixed number of arguments! */
         range.i_det = strtoul(argv[0], NULL, 10);
         if(range.i_det == 0 || range.i_det > fit->sim->n_det) {
             jabs_message(MSG_ERROR, stderr, "Detector number %zu is not valid (n_det = %zu).\n", range.i_det, fit->sim->n_det);
@@ -1360,7 +1358,7 @@ script_command_status script_add_fit_range(script_session *s, int argc, char * c
         return -1;
     }
     fit_data_fit_range_add(fit, &range);
-    return 0;
+    return argc; /* TODO: we can't rely on fixed number of arguments! */
 }
 
 script_command_status script_help(script_session *s, int argc, char * const *argv) {
@@ -1377,7 +1375,7 @@ script_command_status script_help(script_session *s, int argc, char * const *arg
     };
     if(argc == 0) {
         jabs_message(MSG_INFO, stderr, "Type help [topic] for information on a particular topic or \"help help\" for help on help.\n");
-        return 0;
+        return SCRIPT_COMMAND_FAILURE;
     }
 
     int found = 0;
@@ -1452,7 +1450,7 @@ script_command_status script_help(script_session *s, int argc, char * const *arg
         jabs_message(MSG_ERROR, stderr,"Sorry, no help for '%s' available.\n", argv[0]);
         return SCRIPT_COMMAND_NOT_FOUND;
     }
-    return SCRIPT_COMMAND_SUCCESS;
+    return 1; /* TODO: this stuff only works with one argument, right? */
 }
 
 

--- a/script_command.c
+++ b/script_command.c
@@ -452,9 +452,8 @@ script_command_status script_execute_command_argv(script_session *s, const scrip
                 fprintf(stderr, "Debug: Command run, returned %i (%s). Number of arguments remaining: %i\n", status,
                         script_command_status_to_string(status), argc);
 #endif
-                if(status == SCRIPT_COMMAND_FAILURE) {
-                    jabs_message(MSG_ERROR, stderr, "Command failed.\n");
-                    return SCRIPT_COMMAND_FAILURE;
+                if(status < 0 && status != SCRIPT_COMMAND_NOT_FOUND) { /* Command not found is acceptable, we try to find subcommands later. All other errors cause an immediate return. */
+                    return status;
                 }
             } else if(c->var) {
                 if(!c_parent) {

--- a/script_command.c
+++ b/script_command.c
@@ -441,24 +441,6 @@ script_command_status script_set_detector_val(struct script_session *s, int val,
     }
     double *value_double = NULL;
     size_t *value_size = NULL;
-
-#if 0
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("aperture", "Set aperture", 0, &script_set_detector_aperture));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("calibration", "Set calibration", 0, &script_set_detector_calibration));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("column", "", 'c', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("channels", "", 'h', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("compress", "", 'C', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("distance", "", 'd', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("foil", "Set foil", 0, &script_set_detector_foil));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("type", "", 't', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("slope", "", 'S', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("offset", "", 'O', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("resolution", "", 'r', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("solid", "", 's', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("theta", "", 'T', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("length", "", 'l', NULL));
-    script_command_list_add_command(&c_detector->subcommands, script_command_new("phi", "", 'p', NULL));
-#endif
     switch(val) {
         case 'c': /* column */
             value_size = &(det->column);
@@ -475,14 +457,15 @@ script_command_status script_set_detector_val(struct script_session *s, int val,
         case 't': /* type */
             det->type = jibal_option_get_value(detector_option, argv[0]);
             if(det->type == 0) {
-                jabs_message(MSG_WARNING, stderr, "Detector type \"%s\" is none or unknown.\n", argv[0]);
+                jabs_message(MSG_ERROR, stderr, "Detector type \"%s\" is none or unknown.\n", argv[0]);
+                return SCRIPT_COMMAND_FAILURE;
             }
             break;
-        case 'S': /* slope */
-            value_double = &(det->slope);
+        case 'S': /* slope, this is for backwards compatibility (and ease of use with linear calibration) */
+            value_double = calibration_get_param_ref(det->calibration, CALIBRATION_PARAM_SLOPE);
             break;
-        case 'O': /* offset */
-            value_double = &(det->offset);
+        case 'O': /* offset, this is for backwards compatibility */
+            value_double = calibration_get_param_ref(det->calibration, CALIBRATION_PARAM_OFFSET);
             break;
         case 'r': /* resolution */
             value_double = &(det->resolution);

--- a/script_command.c
+++ b/script_command.c
@@ -21,7 +21,9 @@
 #include "options.h"
 #include "jabs.h"
 #include "generic.h"
+#include "script_session.h"
 #include "script_command.h"
+
 
 int script_prepare_sim_or_fit(script_session *s) {
     fit_data *fit = s->fit;
@@ -779,13 +781,13 @@ void script_command_free(script_command *c) {
 void script_commands_free(script_command *head) {
     if(!head)
         return;
-    struct script_command *stack[COMMAND_DEPTH];
+    struct script_command *stack[SCRIPT_NESTED_MAX];
     struct script_command *c, *c_old = NULL;
     stack[0] = head;
     size_t i = 0;
     c = stack[0];
     while(c) {
-        if(c->subcommands && i < COMMAND_DEPTH) { /* Go deeper, push existing pointer to stack */
+        if(c->subcommands && i < SCRIPT_NESTED_MAX) { /* Go deeper, push existing pointer to stack */
             stack[i] = c;
             i++;
             c = c->subcommands;
@@ -1041,7 +1043,7 @@ size_t script_commands_size(const script_command *commands) {
 }
 
 void script_print_command_tree(FILE *f, const struct script_command *commands) {
-    const struct script_command *stack[COMMAND_DEPTH];
+    const struct script_command *stack[SCRIPT_NESTED_MAX];
     const struct script_command *c;
     stack[0] = commands;
     size_t i = 0;
@@ -1057,7 +1059,7 @@ void script_print_command_tree(FILE *f, const struct script_command *commands) {
             }
             jabs_message(MSG_INFO, f, "%s\n", c->name);
         }
-        if(c->subcommands && i < COMMAND_DEPTH) { /* Go deeper, push existing pointer to stack */
+        if(c->subcommands && i < SCRIPT_NESTED_MAX) { /* Go deeper, push existing pointer to stack */
             stack[i] = c;
             i++;
             c = c->subcommands;

--- a/script_command.h
+++ b/script_command.h
@@ -49,8 +49,6 @@ struct help_topic {
 
 const char *script_command_status_to_string(script_command_status status);
 
-int script_getopt(struct script_session *s, const script_command *commands, int *argc, char *const **argv, script_command_status *status_out); /* Parses argument vector, finds script_command_option "c" and calls "c->f()" or sets c->var. */
-
 script_command *script_command_new(const char *name, const char *help_text, int val, script_command_status (*f)(struct script_session *, int, char * const *)); /* Allocates new command that doesn't do anything. Can return var. */
 int script_command_set_var(script_command *c, jibal_config_var_type type, void *variable, const jibal_option *option_list);
 void script_command_free(script_command *c);
@@ -109,6 +107,9 @@ script_command_status script_simulate(struct script_session *s, int argc, char *
 script_command_status script_set_aperture(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_ion(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_detector(struct script_session *s, int argc, char * const *argv);
+script_command_status script_set_detector_aperture(struct script_session *s, int argc, char * const *argv);
+script_command_status script_set_detector_calibration(struct script_session *s, int argc, char * const *argv);
+script_command_status script_set_detector_foil(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_sample(struct script_session *s, int argc, char * const *argv);
 
 #endif //JABS_SCRIPT_COMMAND_H

--- a/script_command.h
+++ b/script_command.h
@@ -30,7 +30,7 @@ void script_command_list_add_command(script_command **head, script_command *c_ne
 script_command *script_command_list_from_command_array(const script_command *commands); /* commands is an array, must be "null-terminated" (name of last element is NULL pointer). Deep copy will be made. */
 script_command *script_command_list_from_vars_array(const jibal_config_var *vars, jibal_config_var_type type); /* vars is an array, must be "null-terminated" (name of last element is NULL pointer). Deep copy will be made. Can be restricted to type. */
 
-
+int script_do_we_need_erd(const struct script_session *s);
 script_command *script_commands_create(struct script_session *s);
 int command_compare(const void *a, const void *b);
 void script_commands_print(FILE *f, const struct script_command *commands);

--- a/script_command.h
+++ b/script_command.h
@@ -70,7 +70,7 @@ script_command_status script_execute_command(struct script_session *s, const cha
 script_command_status script_execute_command_argv(struct script_session *s, const script_command *commands, int argc, char **argv);
 void script_command_not_found(const char *cmd, const script_command *c);
 const script_command *script_command_find(const script_command *commands, const char *cmd_string);
-
+size_t script_command_print_possible_matches_if_ambiguous(const script_command *commands, const char *cmd_string);
 script_command_status script_set_var(struct script_session *s, jibal_config_var *var, int, char * const *);
 script_command_status script_enable_var(struct script_session *s, jibal_config_var *var, int, char * const *);
 script_command_status script_disable_var(struct script_session *s, jibal_config_var *var, int, char * const *);

--- a/script_command.h
+++ b/script_command.h
@@ -21,13 +21,13 @@ struct script_session;
 
 #define COMMAND_DEPTH 8
 
-typedef enum script_command_status {
-    SCRIPT_COMMAND_SUCCESS = EXIT_SUCCESS,
-    SCRIPT_COMMAND_FAILURE = EXIT_FAILURE,
-    SCRIPT_COMMAND_NOT_FOUND = 101,
-    SCRIPT_COMMAND_EXIT = 102,
-    SCRIPT_COMMAND_EOF = 103
-} script_command_status;
+#define SCRIPT_COMMAND_SUCCESS (0) /* Anything above and including zero is success */
+#define SCRIPT_COMMAND_FAILURE (-1)
+#define SCRIPT_COMMAND_NOT_FOUND (-2)
+#define SCRIPT_COMMAND_EXIT (-3)
+#define SCRIPT_COMMAND_EOF (-4)
+
+typedef int script_command_status; /* Script commands should return negative on error (see defines above) and number of arguments (zero or positive) consumed successfully */
 
 typedef struct script_command {
     char *name;

--- a/script_command.h
+++ b/script_command.h
@@ -46,6 +46,8 @@ const script_command *script_command_find(const script_command *commands, const 
 size_t script_command_print_possible_matches_if_ambiguous(const script_command *commands, const char *cmd_string);
 script_command_status script_set_var(struct script_session *s, jibal_config_var *var, int, char * const *);
 script_command_status script_show_var(struct script_session *s, jibal_config_var *var, int, char * const *);
+script_command_status script_set_detector_val(struct script_session *s, int val, int argc, char *const *argv);
+script_command_status script_set_detector_calibration_val(struct script_session *s, int val, int argc, char *const *argv);
 script_command_status script_enable_var(struct script_session *s, jibal_config_var *var, int, char * const *);
 script_command_status script_disable_var(struct script_session *s, jibal_config_var *var, int, char * const *);
 script_command_status script_add_detector(struct script_session *s, int argc, char * const *argv);

--- a/script_command.h
+++ b/script_command.h
@@ -11,41 +11,12 @@
     See LICENSE.txt for the full license.
 
  */
+
+
 #ifndef JABS_SCRIPT_COMMAND_H
 #define JABS_SCRIPT_COMMAND_H
 
-
-struct script_session;
-
-#include "script_session.h"
-
-#define COMMAND_DEPTH 8
-
-#define SCRIPT_COMMAND_SUCCESS (0) /* Anything above and including zero is success */
-#define SCRIPT_COMMAND_FAILURE (-1)
-#define SCRIPT_COMMAND_NOT_FOUND (-2)
-#define SCRIPT_COMMAND_EXIT (-3)
-#define SCRIPT_COMMAND_EOF (-4)
-
-typedef int script_command_status; /* Script commands should return negative on error (see defines above) and number of arguments (zero or positive) consumed successfully */
-
-typedef struct script_command {
-    char *name;
-    script_command_status (*f)(struct script_session *, int, char * const *); /* Function to process argument vectors. Called if it is non-NULL, even if subcommands exist! Return value is important.*/
-    script_command_status (*f_var)(struct script_session *, jibal_config_var *var, int, char * const *); /* Function to process variables (from subcommands). */
-    script_command_status (*f_val)(struct script_session *, int, int, char * const *); /* Function to process vals (from subcommands). */
-    char *help_text; /* Short help text */
-    struct script_command *subcommands;
-    jibal_config_var *var;
-    int val;
-    struct script_command *next;
-} script_command;
-
-struct help_topic {
-    const char *name;
-    const char *help_text;
-};
-
+#include "script_generic.h"
 
 const char *script_command_status_to_string(script_command_status status);
 

--- a/script_command.h
+++ b/script_command.h
@@ -66,6 +66,7 @@ script_command_status script_reset_experimental(struct script_session *s, int ar
 script_command_status script_reset_fit_ranges(struct script_session *s, int argc, char * const *argv);
 script_command_status script_reset_reactions(struct script_session *s, int argc, char * const *argv);
 script_command_status script_reset_sample(struct script_session *s, int argc, char * const *argv);
+script_command_status script_reset_stopping(struct script_session *s, int argc, char * const *argv);
 script_command_status script_roi(struct script_session *s, int argc, char * const *argv);
 script_command_status script_save_bricks(struct script_session *s, int argc, char * const *argv);
 script_command_status script_save_detector(struct script_session *s, int argc, char * const *argv);
@@ -76,6 +77,7 @@ script_command_status script_show_fit(struct script_session *s, int argc, char *
 script_command_status script_show_reactions(struct script_session *s, int argc, char * const *argv);
 script_command_status script_show_sample(struct script_session *s, int argc, char * const *argv);
 script_command_status script_show_simulation(struct script_session *s, int argc, char * const *argv);
+script_command_status script_show_stopping(script_session *s, int argc, char * const *argv);
 script_command_status script_simulate(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_aperture(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_ion(struct script_session *s, int argc, char * const *argv);
@@ -84,5 +86,6 @@ script_command_status script_set_detector_aperture(struct script_session *s, int
 script_command_status script_set_detector_calibration(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_detector_foil(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_sample(struct script_session *s, int argc, char * const *argv);
+script_command_status script_set_stopping(struct script_session *s, int argc, char * const *argv);
 
 #endif //JABS_SCRIPT_COMMAND_H

--- a/script_command.h
+++ b/script_command.h
@@ -45,10 +45,13 @@ struct help_topic {
     const char *help_text;
 };
 
+
+const char *script_command_status_to_string(script_command_status status);
+
 int script_getopt(struct script_session *s, const script_command *commands, int *argc, char *const **argv, script_command_status *status_out); /* Parses argument vector, finds script_command_option "c" and calls "c->f()" or sets c->var. */
 
 script_command *script_command_new(const char *name, const char *help_text, int val, script_command_status (*f)(struct script_session *, int, char * const *)); /* Allocates new command that doesn't do anything. Can return var. */
-int script_command_set_var(script_command *c, jibal_config_var_type type, const void *variable, const jibal_option *option_list);
+int script_command_set_var(script_command *c, jibal_config_var_type type, void *variable, const jibal_option *option_list);
 void script_command_free(script_command *c);
 void script_commands_free(script_command *head);
 
@@ -69,13 +72,12 @@ void script_command_not_found(const char *cmd, const script_command *c);
 const script_command *script_command_find(const script_command *commands, const char *cmd_string);
 
 script_command_status script_set_var(struct script_session *s, jibal_config_var *var, int, char * const *);
-script_command_status script_set_boolean(struct script_session *s, const char *variable, int value);
+script_command_status script_enable_var(struct script_session *s, jibal_config_var *var, int, char * const *);
+script_command_status script_disable_var(struct script_session *s, jibal_config_var *var, int, char * const *);
 script_command_status script_add_detector(struct script_session *s, int argc, char * const *argv);
 script_command_status script_add_fit_range(struct script_session *s, int argc, char * const *argv);
 script_command_status script_add_reaction(struct script_session *s, int argc, char * const *argv);
 script_command_status script_add_reactions(struct script_session *s, int argc, char * const *argv);
-script_command_status script_disable(struct script_session *s, int argc, char * const *argv);
-script_command_status script_enable(struct script_session *s, int argc, char * const *argv);
 script_command_status script_exit(struct script_session *s, int argc, char * const *argv);
 script_command_status script_fit(struct script_session *s, int argc, char * const *argv);
 script_command_status script_help(struct script_session *s, int argc, char * const *argv);
@@ -104,7 +106,6 @@ script_command_status script_show_simulation(struct script_session *s, int argc,
 script_command_status script_show_variables(struct script_session *s, int argc, char * const *argv);
 script_command_status script_simulate(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_aperture(struct script_session *s, int argc, char * const *argv);
-script_command_status script_set_beam(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_ion(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_detector(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_sample(struct script_session *s, int argc, char * const *argv);

--- a/script_command.h
+++ b/script_command.h
@@ -26,12 +26,15 @@ void script_command_free(script_command *c);
 void script_commands_free(script_command *head);
 
 script_command *script_command_list_find_tail(script_command *head);
+script_command *script_command_list_merge(script_command *left, script_command *right);
+script_command *script_command_list_merge_sort(script_command *head); /* Performs a merge sort of command list, sorts in alphabetical order by command name. Does not sort subcommands. */
+script_command *script_command_list_append(script_command *head, script_command *cmd);
 void script_command_list_add_command(script_command **head, script_command *c_new);
 script_command *script_command_list_from_command_array(const script_command *commands); /* commands is an array, must be "null-terminated" (name of last element is NULL pointer). Deep copy will be made. */
 script_command *script_command_list_from_vars_array(const jibal_config_var *vars, jibal_config_var_type type); /* vars is an array, must be "null-terminated" (name of last element is NULL pointer). Deep copy will be made. Can be restricted to type. */
 
-int script_do_we_need_erd(const struct script_session *s);
 script_command *script_commands_create(struct script_session *s);
+script_command *script_commands_sort_all(script_command *head); /* Sorts all commands (tree) so that each subcommand (branch) is sorted by script_command_list_merge_sort() */
 int command_compare(const void *a, const void *b);
 void script_commands_print(FILE *f, const struct script_command *commands);
 size_t script_commands_size(const script_command *commands);

--- a/script_command.h
+++ b/script_command.h
@@ -73,7 +73,6 @@ void script_command_not_found(const char *cmd, const script_command *c);
 const script_command *script_command_find(const script_command *commands, const char *cmd_string);
 size_t script_command_print_possible_matches_if_ambiguous(const script_command *commands, const char *cmd_string);
 script_command_status script_set_var(struct script_session *s, jibal_config_var *var, int, char * const *);
-script_command_status script_set_detector_var(struct script_session *s, jibal_config_var *var, int argc,  char * const *argv);
 script_command_status script_show_var(struct script_session *s, jibal_config_var *var, int, char * const *);
 script_command_status script_enable_var(struct script_session *s, jibal_config_var *var, int, char * const *);
 script_command_status script_disable_var(struct script_session *s, jibal_config_var *var, int, char * const *);
@@ -106,12 +105,10 @@ script_command_status script_show_fit(struct script_session *s, int argc, char *
 script_command_status script_show_reactions(struct script_session *s, int argc, char * const *argv);
 script_command_status script_show_sample(struct script_session *s, int argc, char * const *argv);
 script_command_status script_show_simulation(struct script_session *s, int argc, char * const *argv);
-script_command_status script_show_variables(struct script_session *s, int argc, char * const *argv);
 script_command_status script_simulate(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_aperture(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_ion(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_detector(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_sample(struct script_session *s, int argc, char * const *argv);
-script_command_status script_set_variable(struct script_session *s, int argc, char * const *argv);
 
 #endif //JABS_SCRIPT_COMMAND_H

--- a/script_command.h
+++ b/script_command.h
@@ -52,6 +52,8 @@ script_command_status script_add_reactions(struct script_session *s, int argc, c
 script_command_status script_exit(struct script_session *s, int argc, char * const *argv);
 script_command_status script_fit(struct script_session *s, int argc, char * const *argv);
 script_command_status script_help(struct script_session *s, int argc, char * const *argv);
+script_command_status script_help_version(struct script_session *s, int argc, char *const *argv);
+script_command_status script_help_commands(script_session *s, int argc, char *const *argv);
 script_command_status script_load_detector(struct script_session *s, int argc, char *const *argv);
 script_command_status script_load_experimental(struct script_session *s, int argc, char *const *argv);
 script_command_status script_load_reaction(struct script_session *s, int argc, char *const *argv);

--- a/script_command.h
+++ b/script_command.h
@@ -11,6 +11,11 @@
     See LICENSE.txt for the full license.
 
  */
+#ifndef JABS_SCRIPT_COMMAND_H
+#define JABS_SCRIPT_COMMAND_H
+
+
+struct script_session;
 
 #include "script_session.h"
 
@@ -51,57 +56,57 @@ int option_compare(const void *a, const void *b);
 size_t options_size(const script_command_option *opt);
 void options_print(FILE *f, const script_command_option *options);
 char *options_list_matches(const script_command_option *options, const char *str);
-int script_getopt(script_session *s, const script_command_option *options, int *argc, char *const **argv, script_command_status *status_out); /* Parses argument vector, finds script_command_option "c" and calls "c->f()" or sets c->var. */
+int script_getopt(struct script_session *s, const script_command_option *options, int *argc, char *const **argv, script_command_status *status_out); /* Parses argument vector, finds script_command_option "c" and calls "c->f()" or sets c->var. */
 
 void script_print_commands(FILE *f, const struct script_command *commands);
 size_t script_commands_size(const script_command *commands);
 void script_print_command_tree(FILE *f, const struct script_command *commands);
-script_command_status script_execute_command(script_session *s, const char *cmd);
-script_command_status script_execute_command_argv(script_session *s, const script_command *commands, int argc, char **argv);
+script_command_status script_execute_command(struct script_session *s, const char *cmd);
+script_command_status script_execute_command_argv(struct script_session *s, const script_command *commands, int argc, char **argv);
 void script_command_not_found(const char *cmd, const script_command *c);
 const script_command *script_command_find(const script_command *commands, const char *cmd_string);
-script_command_status script_set_boolean(script_session *s, const char *variable, int value);
+script_command_status script_set_boolean(struct script_session *s, const char *variable, int value);
 
-script_command_status script_add_detector(script_session *s, int argc, char * const *argv);
-script_command_status script_add_fit_range(script_session *s, int argc, char * const *argv);
-script_command_status script_add_reaction(script_session *s, int argc, char * const *argv);
-script_command_status script_add_reactions(script_session *s, int argc, char * const *argv);
-script_command_status script_disable(script_session *s, int argc, char * const *argv);
-script_command_status script_enable(script_session *s, int argc, char * const *argv);
-script_command_status script_exit(script_session *s, int argc, char * const *argv);
-script_command_status script_fit(script_session *s, int argc, char * const *argv);
-script_command_status script_help(script_session *s, int argc, char * const *argv);
-script_command_status script_load_detector(script_session *s, int argc, char *const *argv);
-script_command_status script_load_experimental(script_session *s, int argc, char *const *argv);
-script_command_status script_load_reaction(script_session *s, int argc, char *const *argv);
-script_command_status script_load_sample(script_session *s, int argc, char *const *argv);
-script_command_status script_load_script(script_session *s, int argc, char *const *argv);
-script_command_status script_remove_reaction(script_session *s, int argc, char * const *argv);
-script_command_status script_reset(script_session *s, int argc, char * const *argv);
-script_command_status script_reset_detectors(script_session *s, int argc, char * const *argv);
-script_command_status script_reset_experimental(script_session *s, int argc, char * const *argv);
-script_command_status script_reset_fit_ranges(script_session *s, int argc, char * const *argv);
-script_command_status script_reset_reactions(script_session *s, int argc, char * const *argv);
-script_command_status script_reset_sample(script_session *s, int argc, char * const *argv);
-script_command_status script_roi(script_session *s, int argc, char * const *argv);
-script_command_status script_save_bricks(script_session *s, int argc, char * const *argv);
-script_command_status script_save_detector(script_session *s, int argc, char * const *argv);
-script_command_status script_save_sample(script_session *s, int argc, char * const *argv);
-script_command_status script_save_spectra(script_session *s, int argc, char * const *argv);
-script_command_status script_show_detector(script_session *s, int argc, char * const *argv);
-script_command_status script_show_fit(script_session *s, int argc, char * const *argv);
-script_command_status script_show_reactions(script_session *s, int argc, char * const *argv);
-script_command_status script_show_sample(script_session *s, int argc, char * const *argv);
-script_command_status script_show_simulation(script_session *s, int argc, char * const *argv);
-script_command_status script_show_variables(script_session *s, int argc, char * const *argv);
-script_command_status script_simulate(script_session *s, int argc, char * const *argv);
-script_command_status script_set(script_session *s, int argc, char * const *argv);
-script_command_status script_set_aperture(script_session *s, int argc, char * const *argv);
-script_command_status script_set_beam(script_session *s, int argc, char * const *argv);
-script_command_status script_set_ion(script_session *s, int argc, char * const *argv);
-script_command_status script_set_detector(script_session *s, int argc, char * const *argv);
-script_command_status script_set_sample(script_session *s, int argc, char * const *argv);
-script_command_status script_set_variable(script_session *s, int argc, char * const *argv);
+script_command_status script_add_detector(struct script_session *s, int argc, char * const *argv);
+script_command_status script_add_fit_range(struct script_session *s, int argc, char * const *argv);
+script_command_status script_add_reaction(struct script_session *s, int argc, char * const *argv);
+script_command_status script_add_reactions(struct script_session *s, int argc, char * const *argv);
+script_command_status script_disable(struct script_session *s, int argc, char * const *argv);
+script_command_status script_enable(struct script_session *s, int argc, char * const *argv);
+script_command_status script_exit(struct script_session *s, int argc, char * const *argv);
+script_command_status script_fit(struct script_session *s, int argc, char * const *argv);
+script_command_status script_help(struct script_session *s, int argc, char * const *argv);
+script_command_status script_load_detector(struct script_session *s, int argc, char *const *argv);
+script_command_status script_load_experimental(struct script_session *s, int argc, char *const *argv);
+script_command_status script_load_reaction(struct script_session *s, int argc, char *const *argv);
+script_command_status script_load_sample(struct script_session *s, int argc, char *const *argv);
+script_command_status script_load_script(struct script_session *s, int argc, char *const *argv);
+script_command_status script_remove_reaction(struct script_session *s, int argc, char * const *argv);
+script_command_status script_reset(struct script_session *s, int argc, char * const *argv);
+script_command_status script_reset_detectors(struct script_session *s, int argc, char * const *argv);
+script_command_status script_reset_experimental(struct script_session *s, int argc, char * const *argv);
+script_command_status script_reset_fit_ranges(struct script_session *s, int argc, char * const *argv);
+script_command_status script_reset_reactions(struct script_session *s, int argc, char * const *argv);
+script_command_status script_reset_sample(struct script_session *s, int argc, char * const *argv);
+script_command_status script_roi(struct script_session *s, int argc, char * const *argv);
+script_command_status script_save_bricks(struct script_session *s, int argc, char * const *argv);
+script_command_status script_save_detector(struct script_session *s, int argc, char * const *argv);
+script_command_status script_save_sample(struct script_session *s, int argc, char * const *argv);
+script_command_status script_save_spectra(struct script_session *s, int argc, char * const *argv);
+script_command_status script_show_detector(struct script_session *s, int argc, char * const *argv);
+script_command_status script_show_fit(struct script_session *s, int argc, char * const *argv);
+script_command_status script_show_reactions(struct script_session *s, int argc, char * const *argv);
+script_command_status script_show_sample(struct script_session *s, int argc, char * const *argv);
+script_command_status script_show_simulation(struct script_session *s, int argc, char * const *argv);
+script_command_status script_show_variables(struct script_session *s, int argc, char * const *argv);
+script_command_status script_simulate(struct script_session *s, int argc, char * const *argv);
+script_command_status script_set(struct script_session *s, int argc, char * const *argv);
+script_command_status script_set_aperture(struct script_session *s, int argc, char * const *argv);
+script_command_status script_set_beam(struct script_session *s, int argc, char * const *argv);
+script_command_status script_set_ion(struct script_session *s, int argc, char * const *argv);
+script_command_status script_set_detector(struct script_session *s, int argc, char * const *argv);
+script_command_status script_set_sample(struct script_session *s, int argc, char * const *argv);
+script_command_status script_set_variable(struct script_session *s, int argc, char * const *argv);
 
 
 static const struct script_command script_set_commands[] = {
@@ -181,3 +186,5 @@ static const struct script_command script_commands[] = {
         {"simulate", &script_simulate, "Run a simulation.",                           NULL},
         {NULL,     NULL, NULL,                                                        NULL},
 };
+
+#endif //JABS_SCRIPT_COMMAND_H

--- a/script_command.h
+++ b/script_command.h
@@ -34,6 +34,8 @@ typedef struct script_command {
     script_command_status (*f)(struct script_session *, int, char * const *);
     const char *help_text; /* Short help text */
     const struct script_command *subcommands;
+    jibal_config_var *var;
+    int val;
 } script_command;
 
 struct help_topic {
@@ -41,24 +43,14 @@ struct help_topic {
     const char *help_text;
 };
 
-typedef struct script_command_option { /* Command options are parsed by name, store an int and optionally a pointer to script command (c) or configuration variable (var). */
-    const char *name;
-    int val;
-    const script_command *c;
-    jibal_config_var *var;
-} script_command_option; /* Note that name, c and var are all const pointers. No deep copies are made! */
+int script_getopt(struct script_session *s, const script_command *commands, int *argc, char *const **argv, script_command_status *status_out); /* Parses argument vector, finds script_command_option "c" and calls "c->f()" or sets c->var. */
 
-script_command_option *options_from_commands(const script_command *commands);
-script_command_option *options_from_jibal_config(jibal_config_var *vars);
-script_command_option *options_append(script_command_option *opt_to, const script_command_option *opt_from);
-void options_sort(script_command_option *opt);
-int option_compare(const void *a, const void *b);
-size_t options_size(const script_command_option *opt);
-void options_print(FILE *f, const script_command_option *options);
-char *options_list_matches(const script_command_option *options, const char *str);
-int script_getopt(struct script_session *s, const script_command_option *options, int *argc, char *const **argv, script_command_status *status_out); /* Parses argument vector, finds script_command_option "c" and calls "c->f()" or sets c->var. */
-
-void script_print_commands(FILE *f, const struct script_command *commands);
+struct script_command *script_commands_create(struct script_session *s);
+script_command *script_commands_append(script_command *c_to, const script_command *c_from);
+void script_commands_sort(script_command *commands);
+int command_compare(const void *a, const void *b);
+script_command *script_commands_from_jibal_config(jibal_config_var *vars);
+void script_commands_print(FILE *f, const struct script_command *commands);
 size_t script_commands_size(const script_command *commands);
 void script_print_command_tree(FILE *f, const struct script_command *commands);
 script_command_status script_execute_command(struct script_session *s, const char *cmd);
@@ -100,91 +92,11 @@ script_command_status script_show_sample(struct script_session *s, int argc, cha
 script_command_status script_show_simulation(struct script_session *s, int argc, char * const *argv);
 script_command_status script_show_variables(struct script_session *s, int argc, char * const *argv);
 script_command_status script_simulate(struct script_session *s, int argc, char * const *argv);
-script_command_status script_set(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_aperture(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_beam(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_ion(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_detector(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_sample(struct script_session *s, int argc, char * const *argv);
 script_command_status script_set_variable(struct script_session *s, int argc, char * const *argv);
-
-
-static const struct script_command script_set_commands[] = {
-        {"aperture", &script_set_aperture, "Set aperture.",               NULL},
-        {"beam",     &script_set_beam,     "Set beam properties.",        NULL},
-        {"detector", &script_set_detector, "Set detector properties.",    NULL},
-        {"ion",      &script_set_ion,      "Set incident ion (isotope).", NULL},
-        {"sample",   &script_set_sample,   "Set sample.",                 NULL},
-        {"variable", &script_set_variable, "Set a variable",              NULL},
-        {NULL, NULL, NULL,                                                NULL}
-};
-
-static const struct script_command script_load_commands[] = {
-        {"detector",     &script_load_detector,     "Load (replace) a detector.",     NULL},
-        {"experimental", &script_load_experimental, "Load an experimental spectrum.", NULL},
-        {"script",       &script_load_script,       "Load (run) a script.",           NULL},
-        {"sample",       &script_load_sample,       "Load a sample.",                 NULL},
-        {"reaction",     &script_load_reaction,     "Load a reaction from R33 file.", NULL},
-        {NULL, NULL, NULL,                                                            NULL}
-};
-
-
-static const struct script_command script_save_commands[] = {
-        {"bricks",   &script_save_bricks,   "Save bricks.",   NULL},
-        {"detector", &script_save_detector, "Save detector.", NULL},
-        {"sample",   &script_save_sample,   "Save sample.",   NULL},
-        {"spectra",  &script_save_spectra,  "Save spectra.",  NULL},
-        {NULL, NULL, NULL,                                    NULL}
-};
-
-static const struct script_command script_add_commands[] = {
-        {"detector",  &script_add_detector,  "Add a detector.",               NULL},
-        {"fit_range", &script_add_fit_range, "Add a fit range",               NULL},
-        {"reaction",  &script_add_reaction,  "Add a reaction.",               NULL},
-        {"reactions", &script_add_reactions, "Add reactions (of some type).", NULL},
-        {NULL, NULL, NULL,                                                    NULL}
-};
-
-static const struct script_command script_show_commands[] = {
-        {"detector",   &script_show_detector,   "Show detector.",   NULL},
-        {"fit",        &script_show_fit,        "Show fit.",        NULL},
-        {"reactions",  &script_show_reactions,  "Show reactions,",  NULL},
-        {"sample",     &script_show_sample,     "Show sample",      NULL},
-        {"simulation", &script_show_simulation, "Show simulation.", NULL},
-        {"variables",  &script_show_variables,  "Show variables.",  NULL},
-        {NULL, NULL, NULL,                                          NULL}
-};
-
-static const struct script_command script_remove_commands[] = {
-        {"reaction", &script_remove_reaction, "Remove reaction.", NULL},
-        {NULL, NULL, NULL,                                        NULL}
-};
-
-static const struct script_command script_reset_commands[] = {
-        {"detectors",    &script_reset_detectors,    "Reset detectors.",            NULL},
-        {"experimental", &script_reset_experimental, "Reset experimental spectra.", NULL},
-        {"fit_ranges",   &script_reset_fit_ranges,   "Reset fit ranges.",           NULL},
-        {"reactions",    &script_reset_reactions,    "Reset reactions.",            NULL},
-        {"sample",       &script_reset_sample,       "Reset sample.",               NULL},
-        {NULL, NULL, NULL,                                                          NULL}
-};
-
-static const struct script_command script_commands[] = {
-        {"add",    NULL,               "Add things.",                 script_add_commands},
-        {"disable",  &script_disable,  "Set boolean variable to false.",              NULL},
-        {"enable",   &script_enable,   "Set boolean variable to true.",               NULL},
-        {"exit",     &script_exit,     "Exit.",                                       NULL},
-        {"fit",      &script_fit,      "Do a fit.",                                   NULL},
-        {"save",   NULL,               "Save something.",             script_save_commands},
-        {"set",      &script_set,      "Set variables.",              script_set_commands},
-        {"show",   NULL,               "Show information on things.", script_show_commands},
-        {"help",     &script_help,     "Print help.",                                 NULL},
-        {"load",   NULL,               "Load something.",             script_load_commands},
-        {"remove", NULL,               "Remove something",            script_remove_commands},
-        {"reset",    &script_reset,    "Reset something.",            script_reset_commands},
-        {"roi",      &script_roi,      "Show information from a region of interest.", NULL},
-        {"simulate", &script_simulate, "Run a simulation.",                           NULL},
-        {NULL,     NULL, NULL,                                                        NULL},
-};
 
 #endif //JABS_SCRIPT_COMMAND_H

--- a/script_command.h
+++ b/script_command.h
@@ -33,6 +33,7 @@ typedef struct script_command {
     char *name;
     script_command_status (*f)(struct script_session *, int, char * const *); /* Function to process argument vectors. Called if it is non-NULL, even if subcommands exist! Return value is important.*/
     script_command_status (*f_var)(struct script_session *, jibal_config_var *var, int, char * const *); /* Function to process variables (from subcommands). */
+    script_command_status (*f_val)(struct script_session *, int, int, char * const *); /* Function to process vals (from subcommands). */
     char *help_text; /* Short help text */
     struct script_command *subcommands;
     jibal_config_var *var;
@@ -72,6 +73,8 @@ void script_command_not_found(const char *cmd, const script_command *c);
 const script_command *script_command_find(const script_command *commands, const char *cmd_string);
 size_t script_command_print_possible_matches_if_ambiguous(const script_command *commands, const char *cmd_string);
 script_command_status script_set_var(struct script_session *s, jibal_config_var *var, int, char * const *);
+script_command_status script_set_detector_var(struct script_session *s, jibal_config_var *var, int argc,  char * const *argv);
+script_command_status script_show_var(struct script_session *s, jibal_config_var *var, int, char * const *);
 script_command_status script_enable_var(struct script_session *s, jibal_config_var *var, int, char * const *);
 script_command_status script_disable_var(struct script_session *s, jibal_config_var *var, int, char * const *);
 script_command_status script_add_detector(struct script_session *s, int argc, char * const *argv);

--- a/script_file.c
+++ b/script_file.c
@@ -25,6 +25,9 @@
 script_file *script_file_open(const char *filename) {
     script_file *sfile = malloc(sizeof(script_file));
     sfile->filename = strdup_non_null(filename);
+    if(sfile->f == stdin) {
+        sfile->filename = strdup("(standard input)");
+    }
     sfile->line_size = 0;
     sfile->lineno = 0;
     sfile->line = NULL;

--- a/script_file.h
+++ b/script_file.h
@@ -13,15 +13,7 @@
  */
 
 #include <stdio.h>
-
-typedef struct script_file {
-    FILE *f;
-    char *filename;
-    char *line;
-    size_t line_size;
-    size_t lineno;
-    int interactive;
-} script_file;
+#include "script_generic.h"
 
 script_file *script_file_open(const char *filename);
 void script_file_close(script_file *sfile);

--- a/script_generic.h
+++ b/script_generic.h
@@ -21,7 +21,7 @@ typedef struct script_session {
     struct fit_data *fit;
     char *output_filename; /* File name for automatic spectra saving */ /* TODO: multidetector! */
     clock_t start, end;
-    script_file *files[SCRIPT_NESTED_MAX];
+    script_file *files[SCRIPT_FILES_NESTED_MAX];
     size_t file_depth;
     struct script_command *commands;
     size_t i_det_active;

--- a/script_generic.h
+++ b/script_generic.h
@@ -1,0 +1,55 @@
+#ifndef JABS_SCRIPT_GENERIC_H
+#define JABS_SCRIPT_GENERIC_H
+
+#include <time.h>
+#include <jibal.h>
+#include "defaults.h"
+
+struct script_command;
+
+typedef struct script_file {
+    FILE *f;
+    char *filename;
+    char *line;
+    size_t line_size;
+    size_t lineno;
+    int interactive;
+} script_file;
+
+typedef struct script_session {
+    jibal *jibal;
+    struct fit_data *fit;
+    char *output_filename; /* File name for automatic spectra saving */ /* TODO: multidetector! */
+    clock_t start, end;
+    script_file *files[SCRIPT_NESTED_MAX];
+    size_t file_depth;
+    struct script_command *commands;
+    size_t i_det_active;
+} script_session;
+
+#define SCRIPT_COMMAND_SUCCESS (0) /* Anything above and including zero is success */
+#define SCRIPT_COMMAND_FAILURE (-1)
+#define SCRIPT_COMMAND_NOT_FOUND (-2)
+#define SCRIPT_COMMAND_EXIT (-3)
+#define SCRIPT_COMMAND_EOF (-4)
+
+typedef int script_command_status; /* Script commands should return negative on error (see defines above) and number of arguments (zero or positive) consumed successfully */
+
+typedef struct script_command {
+    char *name;
+    script_command_status (*f)(struct script_session *, int, char * const *); /* Function to process argument vectors. Called if it is non-NULL, even if subcommands exist! Return value is important.*/
+    script_command_status (*f_var)(struct script_session *, jibal_config_var *var, int, char * const *); /* Function to process variables (from subcommands). */
+    script_command_status (*f_val)(struct script_session *, int, int, char * const *); /* Function to process vals (from subcommands). */
+    char *help_text; /* Short help text */
+    struct script_command *subcommands;
+    jibal_config_var *var;
+    int val;
+    struct script_command *next;
+} script_command;
+
+struct help_topic {
+    const char *name;
+    const char *help_text;
+};
+
+#endif // JABS_SCRIPT_GENERIC_H

--- a/script_session.c
+++ b/script_session.c
@@ -119,6 +119,7 @@ void script_session_free(script_session *s) {
     sim_free(s->fit->sim);
     sample_model_free(s->fit->sm);
     fit_data_free(s->fit);
+    script_commands_free(s->commands);
     free(s);
 }
 

--- a/script_session.c
+++ b/script_session.c
@@ -37,14 +37,14 @@ script_session *script_session_init(jibal *jibal, simulation *sim) {
     s->output_filename = NULL;
     s->file_depth = 0;
     s->files[0] = NULL;
-    s->commands = script_commands;
+    s->commands = script_commands_create(s);
     return s;
 }
 
 int script_session_reset_vars(script_session *s) {
     free(s->cf->vars);
     s->cf->vars = NULL;
-    return jibal_config_file_set_vars(s->cf, script_make_vars(s)); /* Loading and resetting things can reset some pointers (like fit->det, so we need to update those to the vars */
+    return jibal_config_file_set_vars(s->cf, script_make_vars(s));
 }
 
 jibal_config_var *script_make_vars(script_session *s) {

--- a/script_session.c
+++ b/script_session.c
@@ -16,6 +16,8 @@
 #include <string.h>
 #include "fit.h"
 #include "message.h"
+#include "script_command.h"
+#include "script_file.h"
 #include "script_session.h"
 
 script_session *script_session_init(jibal *jibal, simulation *sim) {

--- a/script_session.c
+++ b/script_session.c
@@ -37,6 +37,7 @@ script_session *script_session_init(jibal *jibal, simulation *sim) {
     s->output_filename = NULL;
     s->file_depth = 0;
     s->files[0] = NULL;
+    s->commands = script_commands;
     return s;
 }
 

--- a/script_session.c
+++ b/script_session.c
@@ -98,11 +98,11 @@ int script_get_detector_number(const simulation *sim, int allow_empty, int * con
     }
     if(*end == '\0') { /* Entire string was valid */
         *i_det = number - 1;
-        if(*i_det > sim->n_det) {
+        if(*i_det >= sim->n_det) {
             jabs_message(MSG_ERROR, stderr, "Detector number %zu is not valid (n_det = %zu).\n", number, sim->n_det);
             return EXIT_FAILURE;
         }
-        *argc -= 1;
+        (*argc)--;
         (*argv)++;
         return EXIT_SUCCESS;
     }

--- a/script_session.c
+++ b/script_session.c
@@ -42,7 +42,7 @@ script_session *script_session_init(jibal *jibal, simulation *sim) {
 }
 
 int script_session_load_script(script_session *s, const char *filename) {
-    if(s->file_depth >= SCRIPT_NESTED_MAX) {
+    if(s->file_depth >= SCRIPT_FILES_NESTED_MAX) {
         jabs_message(MSG_ERROR, stderr, "Script files nested too deep.\n");
         return EXIT_FAILURE;
     }

--- a/script_session.h
+++ b/script_session.h
@@ -25,17 +25,15 @@
 typedef struct script_session {
     jibal *jibal;
     struct fit_data *fit;
-    jibal_config_file *cf; /* a pseudo-configuration "file" for our session */
     char *output_filename; /* File name for automatic spectra saving */ /* TODO: multidetector! */
     clock_t start, end;
     script_file *files[SCRIPT_NESTED_MAX];
     size_t file_depth;
     struct script_command *commands;
+    size_t i_det_active;
 } script_session;
 
 script_session *script_session_init(jibal *jibal, simulation *sim); /* sim can be NULL or a previously initialized sim can be given. Note that it will be free'd by script_session_free()! */
-jibal_config_var *script_make_vars(script_session *s);
-int script_session_reset_vars(script_session *s);
 void script_session_free(script_session *s);
 int script_session_load_script(script_session *s, const char *filename);
 int script_get_detector_number(const simulation *sim, int allow_empty, int *argc, char * const **argv, size_t *i_det);

--- a/script_session.h
+++ b/script_session.h
@@ -30,7 +30,7 @@ typedef struct script_session {
     clock_t start, end;
     script_file *files[SCRIPT_NESTED_MAX];
     size_t file_depth;
-    struct script_command *commands; /* TODO: populate */
+    const struct script_command *commands; /* TODO: populate */
 } script_session;
 
 script_session *script_session_init(jibal *jibal, simulation *sim); /* sim can be NULL or a previously initialized sim can be given. Note that it will be free'd by script_session_free()! */

--- a/script_session.h
+++ b/script_session.h
@@ -38,6 +38,6 @@ jibal_config_var *script_make_vars(script_session *s);
 int script_session_reset_vars(script_session *s);
 void script_session_free(script_session *s);
 int script_session_load_script(script_session *s, const char *filename);
-int script_get_detector_number(const simulation *sim, int allow_empty, int * const argc, char * const ** const argv, size_t *i_det);
+int script_get_detector_number(const simulation *sim, int allow_empty, int *argc, char * const **argv, size_t *i_det);
 
 #endif //JABS_SCRIPT_SESSION_H

--- a/script_session.h
+++ b/script_session.h
@@ -30,7 +30,7 @@ typedef struct script_session {
     clock_t start, end;
     script_file *files[SCRIPT_NESTED_MAX];
     size_t file_depth;
-    struct script_command *commands; /* TODO: populate */
+    struct script_command *commands;
 } script_session;
 
 script_session *script_session_init(jibal *jibal, simulation *sim); /* sim can be NULL or a previously initialized sim can be given. Note that it will be free'd by script_session_free()! */

--- a/script_session.h
+++ b/script_session.h
@@ -30,7 +30,7 @@ typedef struct script_session {
     clock_t start, end;
     script_file *files[SCRIPT_NESTED_MAX];
     size_t file_depth;
-    const struct script_command *commands; /* TODO: populate */
+    struct script_command *commands; /* TODO: populate */
 } script_session;
 
 script_session *script_session_init(jibal *jibal, simulation *sim); /* sim can be NULL or a previously initialized sim can be given. Note that it will be free'd by script_session_free()! */

--- a/script_session.h
+++ b/script_session.h
@@ -11,11 +11,16 @@
     See LICENSE.txt for the full license.
 
  */
+#ifndef JABS_SCRIPT_SESSION_H
+#define JABS_SCRIPT_SESSION_H
+
 
 #include <jibal.h>
 #include "simulation.h"
 #include "script_file.h"
 #include "defaults.h"
+
+#include "script_command.h"
 
 typedef struct script_session {
     jibal *jibal;
@@ -25,6 +30,7 @@ typedef struct script_session {
     clock_t start, end;
     script_file *files[SCRIPT_NESTED_MAX];
     size_t file_depth;
+    struct script_command *commands; /* TODO: populate */
 } script_session;
 
 script_session *script_session_init(jibal *jibal, simulation *sim); /* sim can be NULL or a previously initialized sim can be given. Note that it will be free'd by script_session_free()! */
@@ -33,3 +39,5 @@ int script_session_reset_vars(script_session *s);
 void script_session_free(script_session *s);
 int script_session_load_script(script_session *s, const char *filename);
 int script_get_detector_number(const simulation *sim, int allow_empty, int * const argc, char * const ** const argv, size_t *i_det);
+
+#endif //JABS_SCRIPT_SESSION_H

--- a/script_session.h
+++ b/script_session.h
@@ -17,21 +17,8 @@
 
 #include <jibal.h>
 #include "simulation.h"
-#include "script_file.h"
 #include "defaults.h"
-
-#include "script_command.h"
-
-typedef struct script_session {
-    jibal *jibal;
-    struct fit_data *fit;
-    char *output_filename; /* File name for automatic spectra saving */ /* TODO: multidetector! */
-    clock_t start, end;
-    script_file *files[SCRIPT_NESTED_MAX];
-    size_t file_depth;
-    struct script_command *commands;
-    size_t i_det_active;
-} script_session;
+#include "script_generic.h"
 
 script_session *script_session_init(jibal *jibal, simulation *sim); /* sim can be NULL or a previously initialized sim can be given. Note that it will be free'd by script_session_free()! */
 void script_session_free(script_session *s);

--- a/simulation.c
+++ b/simulation.c
@@ -415,7 +415,7 @@ void sim_workspace_recalculate_n_channels(sim_workspace *ws, const simulation *s
     fprintf(stderr, "E_max of this simulation is %g keV\n", E_max/C_KEV);
 #endif
     size_t i=0;
-    while(detector_calibrated(ws->det, i) < E_max && i <= 1000000) {i++;}
+    while(detector_calibrated(ws->det, i) < E_max && i <= 1000000) {i++;} /* TODO: this requires changes for ToF spectra */
 #ifdef DEBUG
     fprintf(stderr, "Simulating %zu channels\n", i);
 #endif

--- a/simulation.c
+++ b/simulation.c
@@ -459,9 +459,9 @@ void simulation_print(FILE *f, const simulation *sim) {
             jabs_message(MSG_INFO, f, "diameter %g mm\n", sim->beam_aperture->diameter/C_MM);
         } else if(sim->beam_aperture->type == APERTURE_RECTANGLE) {
             jabs_message(MSG_INFO, f, "width %g mm height %g mm\n", sim->beam_aperture->width/C_MM, sim->beam_aperture->height/C_MM);
-        } else {
-            jabs_message(MSG_INFO, f, "\n");
         }
+    } else {
+        jabs_message(MSG_INFO, f, "\n");
     }
     jabs_message(MSG_INFO, f, "n_detectors = %zu\n", sim->n_det);
     for(size_t i = 0; i < sim->n_det; i++) {

--- a/simulation.c
+++ b/simulation.c
@@ -645,3 +645,21 @@ double sim_exit_angle(const simulation *sim, const detector *det) {
     rotate(sim->sample_theta, sim->sample_phi, det->theta, det->phi, &theta, &phi);
     return C_PI - theta;
 }
+
+int sim_do_we_need_erd(const simulation *sim) {
+    if(!sim->erd) {
+        return FALSE; /* ERD has been (intentionally) disabled */
+    }
+    if(sim->params.ds) {
+        return TRUE; /* In case of DS, ERD becomes possible kind-of possible with any detector geometry */
+    }
+    int forward_angles = FALSE;
+    for(size_t i_det = 0; i_det < sim->n_det; i_det++) {
+        const detector *det = sim_det(sim, i_det);
+        if(det->theta < C_PI_2) {
+            forward_angles = TRUE;
+            break;
+        }
+    }
+    return forward_angles; /* If any detector is in forward angle, we might need ERD */
+}

--- a/simulation.h
+++ b/simulation.h
@@ -136,4 +136,5 @@ void sim_sort_reactions(const simulation *sim);
 void sim_reaction_product_energy_and_straggling(sim_reaction *r, const ion *incident);
 double sim_alpha_angle(const simulation *sim);
 double sim_exit_angle(const simulation *sim, const detector *det);
+int sim_do_we_need_erd(const simulation *sim);
 #endif // JABS_SIMULATION_H


### PR DESCRIPTION
Script command parsing restructured again. New commands have been introduced and old ones have been removed. Some commands still need to be adapted better to the new system. Loading and saving detectors does not work and might be deprecated in favour of using regular script syntax (that could be exported to a file?).