### PR TITLE
Concentration fitting improved

### DIFF
--- a/example/example.jbs
+++ b/example/example.jbs
@@ -32,7 +32,7 @@ save spectra "simulated_out.csv"
 
 set fit normal
 
-fit *calib*,fluence,thickness1,thickness2,rough1
+fit *calib*,fluence,thick1,thick2,rough1,conc2_O
 save spectra "example_out.csv"
 #detector calibration can be saved to a script file. This can be loaded back in.
 save calibration "calibration_out.jbs"

--- a/fit.c
+++ b/fit.c
@@ -34,23 +34,31 @@ int fit_function(const gsl_vector *x, void *params, gsl_vector * f)
 #ifdef DEBUG
     fprintf(stderr, "Fit iteration %zu, fit function evaluation %zu\n", fit_data->stats.iter, fit_data->stats.n_evals_iter);
 #endif
-
+    sample_free(fit_data->sim->sample);
+    fit_data->sim->sample = NULL;
+    fit_data_workspaces_free(fit_data);
     for(size_t i = 0; i < fit_data->fit_params->n; i++) {
         fit_variable *var = &fit_data->fit_params->vars[i];
         if(var->active) {
             *(var->value) = gsl_vector_get(x, var->i_v);
         }
     }
-
-    sample_free(fit_data->sim->sample);
+    if(sample_model_sanity_check(fit_data->sm)) {
+        fit_data->stats.error = FIT_ERROR_SANITY;
+        return GSL_FAILURE;
+    }
+    if(sim_sanity_check(fit_data->sim)) {
+        fit_data->stats.error = FIT_ERROR_SANITY;
+        return GSL_FAILURE;
+    }
     fit_data->sim->sample = sample_from_sample_model(fit_data->sm);
     sample_renormalize(fit_data->sim->sample);
-    fit_data_workspaces_free(fit_data);
-    if(sim_sanity_check(fit_data->sim) || fit_data_workspaces_init(fit_data)) { /* Either fails: clean up and return */
+    if(fit_data_workspaces_init(fit_data)) {
         fit_data_workspaces_free(fit_data); /* Some workspaces may have already been allocated */
         fit_data->stats.error = FIT_ERROR_SANITY;
         return GSL_FAILURE;
     }
+
     start = clock();
     for(size_t i_det = 0; i_det < fit_data->sim->n_det; i_det++) {
         simulate_with_ds(fit_data->ws[i_det]);
@@ -99,23 +107,14 @@ void fit_callback(const size_t iter, void *params, const gsl_multifit_nlinear_wo
 
     /* compute reciprocal condition number of J(x) */
     gsl_multifit_nlinear_rcond(&fit_data->stats.rcond, w);
-
-    jabs_message(MSG_INFO, stderr, "iter %2zu: cond(J) = %12.6e, |f(x)| = %14.8e", iter, 1.0 / fit_data->stats.rcond, gsl_blas_dnrm2(f));
-#ifndef NO_CHISQ
     gsl_blas_ddot(f, f, &fit_data->stats.chisq);
     fit_data->stats.chisq_dof = fit_data->stats.chisq/fit_data->dof;
-    jabs_message(MSG_INFO, stderr, ", chisq/dof = %10.7lf", fit_data->stats.chisq_dof);
-#endif
     fit_data->stats.n_evals += fit_data->stats.n_evals_iter;
     fit_data->stats.cputime_cumul += fit_data->stats.cputime_iter;
-    jabs_message(MSG_INFO, stderr, ", eval %3zu, cpu time %7.3lf s, %6.1lf ms per eval", fit_data->stats.n_evals, fit_data->stats.cputime_cumul, 1000.0 * fit_data->stats.cputime_iter / fit_data->stats.n_evals_iter);
-#ifdef FIT_PRINT_PARAMS
-    size_t i;
-    for(i = 0; i < fit_data->fit_params->n; i++) {
-        fprintf(stderr, ", prob[%zu] = %12.6e", i, gsl_vector_get(w->x, i));
-    }
-#endif
-    jabs_message(MSG_INFO, stderr, "\n");
+    jabs_message(MSG_INFO, stderr, "%4zu | %12.6e | %14.8e | %12.7lf | %4zu | %13.3lf | %12.1lf |\n",
+                 iter, 1.0 / fit_data->stats.rcond, gsl_blas_dnrm2(f),
+                 fit_data->stats.chisq_dof, fit_data->stats.n_evals, fit_data->stats.cputime_cumul,
+                 1000.0 * fit_data->stats.cputime_iter / fit_data->stats.n_evals_iter);
 }
 
 fit_params *fit_params_new() {
@@ -457,6 +456,7 @@ int jabs_gsl_multifit_nlinear_driver(const size_t maxiter, const double xtol, co
     size_t iter;
     struct fit_data *fit_data = (struct fit_data *) callback_params;
     double chisq_dof_old;
+    jabs_message(MSG_INFO, stderr, "iter |    cond(J)   |     |f(x)|     |   chisq/dof  | eval | cpu cumul (s) | cpu/eval (ms)|\n");
     for(iter = 0; iter <= maxiter; iter++) {
         if(iter) {
             chisq_dof_old = fit_data->stats.chisq_dof;
@@ -523,7 +523,7 @@ void fit_parameters_update(const fit_data *fit, const gsl_multifit_nlinear_works
     }
 }
 
-void fit_parameters_update_changed(const fit_data *fit, const gsl_multifit_nlinear_workspace *w, const gsl_matrix *covar) {
+void fit_parameters_update_changed(const fit_data *fit) {
     const fit_params *fit_params = fit->fit_params;
     for(size_t i = 0; i < fit_params->n; i++) {
         fit_variable *var = &(fit_params->vars[i]);
@@ -541,11 +541,11 @@ void fit_parameters_update_changed(const fit_data *fit, const gsl_multifit_nline
 void fit_covar_print(const gsl_matrix *covar) {
     jabs_message(MSG_INFO, stderr, "\nCorrelation coefficients matrix:\n       | ");
     for(size_t i = 0; i < covar->size1; i++) {
-        jabs_message(MSG_INFO, stderr, " %4zu  ", i);
+        jabs_message(MSG_INFO, stderr, " %4zu  ", i + 1);
     }
     jabs_message(MSG_INFO, stderr, "\n");
     for(size_t i = 0; i < covar->size1; i++) {
-        jabs_message(MSG_INFO, stderr, "%6zu | ", i);
+        jabs_message(MSG_INFO, stderr, "%6zu | ", i + 1);
         for (size_t j = 0; j <= i && j < covar->size2; j++) {
             jabs_message(MSG_INFO, stderr, " %6.3f", gsl_matrix_get(covar, i, j)/sqrt(gsl_matrix_get(covar, i, i)*gsl_matrix_get(covar, j, j)));
         }
@@ -700,7 +700,7 @@ int fit(struct fit_data *fit_data) {
 
         fit_parameters_update(fit_data, w, covar);
         sample_model_renormalize(fit_data->sm);
-        fit_parameters_update_changed(fit_data, w, covar); /* sample_model_renormalize() can and will change concentration values, this will recompute error (assuming relative error stays the same) */
+        fit_parameters_update_changed(fit_data); /* sample_model_renormalize() can and will change concentration values, this will recompute error (assuming relative error stays the same) */
         fit_params_print_final(fit_params);
         fit_covar_print(covar);
 

--- a/fit.c
+++ b/fit.c
@@ -43,8 +43,8 @@ int fit_function(const gsl_vector *x, void *params, gsl_vector * f)
     }
 
     sample_free(fit_data->sim->sample);
-    sample_model_renormalize(fit_data->sm); /* TODO: not necessary, if sample_from_sample_model() does the renormalization. Also consider fit uncertainties when renormalizing! */
     fit_data->sim->sample = sample_from_sample_model(fit_data->sm);
+    sample_renormalize(fit_data->sim->sample);
     fit_data_workspaces_free(fit_data);
     if(sim_sanity_check(fit_data->sim) || fit_data_workspaces_init(fit_data)) { /* Either fails: clean up and return */
         fit_data_workspaces_free(fit_data); /* Some workspaces may have already been allocated */
@@ -507,10 +507,9 @@ void fit_report_results(const fit_data *fit, const gsl_multifit_nlinear_workspac
     jabs_message(MSG_INFO, stderr, "final   |f(x)| = %f\n", sqrt(fit->stats.chisq));
 }
 
-void fit_report_parameters(const fit_data *fit, const gsl_multifit_nlinear_workspace *w, const gsl_matrix *covar) {
-    const fit_params *fit_params = fit->fit_params;
-    jabs_message(MSG_INFO, stderr, "\nFinal fitted parameters:\n");
 
+void fit_parameters_update(const fit_data *fit, const gsl_multifit_nlinear_workspace *w, const gsl_matrix *covar) {
+    const fit_params *fit_params = fit->fit_params;
     double c = GSL_MAX_DBL(1, sqrt(fit->stats.chisq_dof));
     for(size_t i = 0; i < fit_params->n; i++) { /* Update final fitted values to the table (same as used for initial guess) */
         fit_variable *var = &(fit_params->vars[i]);
@@ -521,22 +520,33 @@ void fit_report_parameters(const fit_data *fit, const gsl_multifit_nlinear_works
         *(var->value) = var->value_final;
         var->err = c * sqrt(gsl_matrix_get(covar, var->i_v, var->i_v));
         var->err_rel = fabs(var->err / var->value_final);
-        jabs_message(MSG_INFO, stderr, "    p[%zu]: %24s (%3s) = %12g +- %12g (%5.1lf%%), %12g x %10.6lf \n", var->i_v, var->name, var->unit,
-                     var->value_final/var->unit_factor,
-                     var->err/var->unit_factor,
-                     100.0 * var->err_rel,
-                     var->value_orig/var->unit_factor,
-                     var->value_final/var->value_orig
-        );
     }
+}
+
+void fit_parameters_update_changed(const fit_data *fit, const gsl_multifit_nlinear_workspace *w, const gsl_matrix *covar) {
+    const fit_params *fit_params = fit->fit_params;
+    for(size_t i = 0; i < fit_params->n; i++) {
+        fit_variable *var = &(fit_params->vars[i]);
+        if(!var->active)
+            continue;
+        if(*(var->value) != var->value_final) { /* Values changed by something (renormalization) */
+            double scale = *(var->value)/var->value_final;
+            var->value_final = (*var->value);
+            var->err *= scale;
+            /* var->err_rel stays the same */
+        }
+    }
+}
+
+void fit_covar_print(const gsl_matrix *covar) {
     jabs_message(MSG_INFO, stderr, "\nCorrelation coefficients matrix:\n       | ");
-    for(size_t i = 0; i < fit_params->n_active; i++) {
+    for(size_t i = 0; i < covar->size1; i++) {
         jabs_message(MSG_INFO, stderr, " %4zu  ", i);
     }
     jabs_message(MSG_INFO, stderr, "\n");
-    for(size_t i = 0; i < fit_params->n_active; i++) {
+    for(size_t i = 0; i < covar->size1; i++) {
         jabs_message(MSG_INFO, stderr, "%6zu | ", i);
-        for (size_t j = 0; j <= i; j++) {
+        for (size_t j = 0; j <= i && j < covar->size2; j++) {
             jabs_message(MSG_INFO, stderr, " %6.3f", gsl_matrix_get(covar, i, j)/sqrt(gsl_matrix_get(covar, i, i)*gsl_matrix_get(covar, j, j)));
         }
         jabs_message(MSG_INFO, stderr, "\n");
@@ -670,7 +680,7 @@ int fit(struct fit_data *fit_data) {
             jabs_message(MSG_ERROR, stderr, "Fit aborted in phase %i, reason: %s.\n", phase, fit_error_str(fit_data->stats.error));
             break;
         }
-        jabs_message(MSG_INFO, stderr,"Phase %i finished. CPU time used for actual simulation: %.3lf s.\n", phase, fit_data->stats.cputime_cumul);
+        jabs_message(MSG_INFO, stderr,"Phase %i finished. CPU time used for actual simulation so far: %.3lf s.\n", phase, fit_data->stats.cputime_cumul);
         fit_report_results(fit_data, w, &fdf);
     }
 
@@ -688,7 +698,11 @@ int fit(struct fit_data *fit_data) {
         gsl_blas_ddot(f, f, &fit_data->stats.chisq);
         fit_data->stats.chisq_dof = fit_data->stats.chisq / fit_data->dof;
 
-        fit_report_parameters(fit_data, w, covar);
+        fit_parameters_update(fit_data, w, covar);
+        sample_model_renormalize(fit_data->sm);
+        fit_parameters_update_changed(fit_data, w, covar); /* sample_model_renormalize() can and will change concentration values, this will recompute error (assuming relative error stays the same) */
+        fit_params_print_final(fit_params);
+        fit_covar_print(covar);
 
         for(size_t i = 0; i < fit_data->sim->n_det; i++) {
             spectrum_set_calibration(fit_data_exp(fit_data, i), sim_det(fit_data->sim, i), JIBAL_ANY_Z); /* Update the experimental spectra to final calibration (using default calibration) */

--- a/fit.h
+++ b/fit.h
@@ -118,6 +118,9 @@ int fit_data_workspaces_init(struct fit_data *fit_data); /* If any workspace ini
 void fit_data_workspaces_free(struct fit_data *fit_data); /* Also sets workspace pointers to NULL */
 struct fit_stats fit_stats_init();
 int fit(struct fit_data *fit_data);
+void fit_covar_print(const gsl_matrix *covar);
+void fit_parameters_update(const fit_data *fit, const gsl_multifit_nlinear_workspace *w, const gsl_matrix *covar); /* Updates values in fit_params, computes errors */
+void fit_parameters_update_changed(const fit_data *fit, const gsl_multifit_nlinear_workspace *w, const gsl_matrix *covar); /* Checks if values have changed since fit_parameters_update(), computes new error */
 int fit_function(const gsl_vector *x, void *params, gsl_vector *f);
 void fit_callback(size_t iter, void *params, const gsl_multifit_nlinear_workspace *w);
 fit_params *fit_params_new();

--- a/fit.h
+++ b/fit.h
@@ -120,7 +120,7 @@ struct fit_stats fit_stats_init();
 int fit(struct fit_data *fit_data);
 void fit_covar_print(const gsl_matrix *covar);
 void fit_parameters_update(const fit_data *fit, const gsl_multifit_nlinear_workspace *w, const gsl_matrix *covar); /* Updates values in fit_params, computes errors */
-void fit_parameters_update_changed(const fit_data *fit, const gsl_multifit_nlinear_workspace *w, const gsl_matrix *covar); /* Checks if values have changed since fit_parameters_update(), computes new error */
+void fit_parameters_update_changed(const fit_data *fit); /* Checks if values have changed since fit_parameters_update(), computes new error */
 int fit_function(const gsl_vector *x, void *params, gsl_vector *f);
 void fit_callback(size_t iter, void *params, const gsl_multifit_nlinear_workspace *w);
 fit_params *fit_params_new();

--- a/jabs.c
+++ b/jabs.c
@@ -920,7 +920,7 @@ void fit_params_print_final(const fit_params *params) { /* Prints final values o
         if(!var->active)
             continue;
         //jabs_message(MSG_INFO, stderr, "%24s(%3s) = %12g +- %12g (%.1lf%%)\n", var->name, var->unit, var->value_final/var->unit_factor, var->err/var->unit_factor, var->err/var->value_final*100.0);
-        jabs_message(MSG_INFO, stderr, "    p[%zu]: %24s (%3s) = %12g +- %12g (%5.1lf%%), %12g x %10.6lf \n", var->i_v, var->name, var->unit,
+        jabs_message(MSG_INFO, stderr, "%3zu | %24s (%3s) = %11.6g +- %9.4g (%5.1lf%%), %12.6g x %6.4lf\n", var->i_v + 1, var->name, var->unit,
                      var->value_final/var->unit_factor,
                      var->err/var->unit_factor,
                      100.0 * var->err_rel,

--- a/jabs.c
+++ b/jabs.c
@@ -663,7 +663,7 @@ fit_params *fit_params_all(fit_data *fit) {
     if(sm) {
         for(size_t i_range = 0; i_range < sm->n_ranges; i_range++) {
             sample_range *r = &(sm->ranges[i_range]);
-            snprintf(param_name, param_name_max_len, "thickness%zu", i_range + 1);
+            snprintf(param_name, param_name_max_len, "thick%zu", i_range + 1);
             fit_params_add_parameter(params, &(r->x), param_name, "tfu", C_TFU);
             if(r->rough.model != ROUGHNESS_NONE) {
                 snprintf(param_name, param_name_max_len, "rough%zu", i_range + 1);
@@ -911,15 +911,22 @@ void fit_params_print_final(const fit_params *params) { /* Prints final values o
     if(!params)
         return;
     if(params->n_active) {
-        jabs_message(MSG_INFO, stderr, "Active fit variables (%zu/%zu):\n", params->n_active, params->n);
+        jabs_message(MSG_INFO, stderr, "Final fit variables (%zu/%zu):\n", params->n_active, params->n);
     } else {
-        jabs_message(MSG_INFO, stderr, "No active fit variables of total %zu.\n", params->n);
+        jabs_message(MSG_INFO, stderr, "No fitted variables of total %zu.\n", params->n);
     }
     for(size_t i = 0; i < params->n; i++) {
         const fit_variable *var = &params->vars[i];
         if(!var->active)
             continue;
-        jabs_message(MSG_INFO, stderr, "%24s(%s) = %g +- %g (%.1lf%%)\n", var->name, var->unit, var->value_final/var->unit_factor, var->err/var->unit_factor, var->err/var->value_final*100.0);
+        //jabs_message(MSG_INFO, stderr, "%24s(%3s) = %12g +- %12g (%.1lf%%)\n", var->name, var->unit, var->value_final/var->unit_factor, var->err/var->unit_factor, var->err/var->value_final*100.0);
+        jabs_message(MSG_INFO, stderr, "    p[%zu]: %24s (%3s) = %12g +- %12g (%5.1lf%%), %12g x %10.6lf \n", var->i_v, var->name, var->unit,
+                     var->value_final/var->unit_factor,
+                     var->err/var->unit_factor,
+                     100.0 * var->err_rel,
+                     var->value_orig/var->unit_factor,
+                     var->value_final/var->value_orig
+        );
     }
 }
 

--- a/sample.h
+++ b/sample.h
@@ -59,6 +59,7 @@ typedef struct sample_model {
 } sample_model;
 
 sample_model *sample_model_alloc(size_t n_materials, size_t n_ranges);
+int sample_model_sanity_check(const sample_model *sm);
 void sample_model_renormalize(sample_model *sm);
 void sample_renormalize(sample *sample);
 sample_model *sample_model_split_elements(const struct sample_model *sm);

--- a/sample.h
+++ b/sample.h
@@ -60,6 +60,7 @@ typedef struct sample_model {
 
 sample_model *sample_model_alloc(size_t n_materials, size_t n_ranges);
 void sample_model_renormalize(sample_model *sm);
+void sample_renormalize(sample *sample);
 sample_model *sample_model_split_elements(const struct sample_model *sm);
 sample_model *sample_model_from_file(const jibal *jibal, const char *filename);
 sample_model *sample_model_from_argv(const jibal *jibal, int *argc, char * const **argv);

--- a/script_command.c
+++ b/script_command.c
@@ -1598,9 +1598,10 @@ script_command_status script_show_fitvar(script_session *s, int argc, char *cons
 }
 
 script_command_status script_show_aperture(struct script_session *s, int argc, char * const *argv) {
+    (void) argv;
     struct fit_data *fit = s->fit;
     const int argc_orig = argc;
-    char *aperture_str = aperture_to_string(s->fit->sim->beam_aperture);
+    char *aperture_str = aperture_to_string(fit->sim->beam_aperture);
     jabs_message(MSG_INFO, stderr, "aperture %s\n", aperture_str);
     free(aperture_str);
     return argc_orig - argc;
@@ -1775,7 +1776,7 @@ script_command_status script_set_detector_calibration_poly(struct script_session
     }
     calibration *c = calibration_init_poly(n);
     calibration_copy_params(c, detector_get_calibration(det, s->Z_active)); /* This, de facto, only copies resolution from old calibration, since the rest are overwritten very soon. */
-    for(int i = 0; i <= n; i++) {
+    for(int i = 0; i <= (int)n; i++) {
         calibration_set_param(c, i, jibal_get_val(s->jibal->units, UNIT_TYPE_ANY, argv[0]));
         argc--;
         argv++;


### PR DESCRIPTION
Sample model is no longer altered during fitting, except by GSL multifit. Concentrations are normalized to sample, but not sample_model. This makes concentration fitting actually work as inteded. Fit errors are also recalculated after renormalization.

Also this PR will make the text output prettier.