### PR TITLE
Accuracy of counts

### DIFF
--- a/src/brick.c
+++ b/src/brick.c
@@ -2,8 +2,8 @@
 #include <assert.h>
 #include <jibal_units.h>
 
-#ifdef ERF_Q_FROM_GSL
-#include <gsl/gsl_sf.h>
+#ifdef NO_ERF_Q_FROM_GSL
+#include <gsl/gsl_sf_erf.h>
 #endif
 #include "brick.h"
 
@@ -80,8 +80,11 @@ void bricks_convolute(gsl_histogram *h, const brick *bricks, size_t last_brick, 
                 break; /* Assumes histograms have increasing energy */
             const double E = (h->range[j] + h->range[j + 1]) / 2.0; /* Approximate gaussian at center bin */
             const double w = h->range[j + 1] - h->range[j];
-            //const double y = (erf_Q((b_low->E - E) / b_low->sigma) - erf_Q((b_high->E - E) / b_high->sigma)) / (b_high->E - b_low->E);
+#ifdef ERF_Q_FROM_GSL
+            const double y = (gsl_sf_erf_Q((b_low->E - E) / b_low->sigma) - gsl_sf_erf_Q((b_high->E - E) / b_high->sigma)) / (b_high->E - b_low->E);
+#else
             const double y = (erf_Q_new((b_low->E - E) / b_low->sigma) - erf_Q_new((b_high->E - E) / b_high->sigma)) / (b_high->E - b_low->E);
+#endif
             h->bin[j] += scale * y * w * b_low->Q;
         }
     }

--- a/src/brick.h
+++ b/src/brick.h
@@ -23,5 +23,5 @@ typedef struct {
 } brick;
 
 void bricks_calculate_sigma(const detector *det, const jibal_isotope *isotope, brick *bricks, size_t last_brick); /* Sums up all the contributions to sigma (including detector resolution) */
-void bricks_convolute(gsl_histogram *h, const brick *bricks, size_t last_brick, double scale, double sigmas_cutoff);
+void bricks_convolute(gsl_histogram *h, const brick *bricks, size_t last_brick, double scale, double sigmas_cutoff, int accurate);
 #endif // JABS_BRICK_H

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -61,4 +61,5 @@
 #define FIT_FAST_CHISQ_TOL (1e-1)  /* Relative change in chi squared to stop fitting (fast fitting phase). This can be quite large, as turning on better physics changes the chisq. */
 #define SIGMAS_CUTOFF (5.0)
 #define SIGMAS_FAST_CUTOFF (3.5)
+#define CS_INTEGRATION_INTERVALS 200
 #endif // JABS_DEFAULTS_H

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -61,5 +61,6 @@
 #define FIT_FAST_CHISQ_TOL (1e-1)  /* Relative change in chi squared to stop fitting (fast fitting phase). This can be quite large, as turning on better physics changes the chisq. */
 #define SIGMAS_CUTOFF (5.0)
 #define SIGMAS_FAST_CUTOFF (3.5)
-#define CS_INTEGRATION_INTERVALS 200
+#define CS_CONC_INTEGRATION_INTERVALS 100
+#define CS_STRAGG_INTEGRATION_INTERVALS 100
 #endif // JABS_DEFAULTS_H

--- a/src/jabs.h
+++ b/src/jabs.h
@@ -36,6 +36,7 @@ int print_bricks(const char *filename, const sim_workspace *ws);
 int simulate_with_ds(sim_workspace *ws);
 void ds(sim_workspace *ws); /* TODO: the DS routine is more pseudocode at this stage... */
 double cross_section_concentration_product(const sim_workspace *ws, const sample *sample, const sim_reaction *sim_r, double E_front, double E_back, const depth *d_before, const depth *d_after, double S_front, double S_back);
+double cross_section_straggling(const sim_reaction *sim_r, const prob_dist *pd, double E, double S);
 fit_params *fit_params_all(fit_data *fit);
 void fit_params_print(const fit_params *params, int active, const char *pattern); /* if active is TRUE print only active variables. pattern can be NULL to bypass matching. */
 void fit_params_print_final(const fit_params *params);

--- a/src/jabs.h
+++ b/src/jabs.h
@@ -36,7 +36,11 @@ int print_bricks(const char *filename, const sim_workspace *ws);
 int simulate_with_ds(sim_workspace *ws);
 void ds(sim_workspace *ws); /* TODO: the DS routine is more pseudocode at this stage... */
 double cross_section_concentration_product(const sim_workspace *ws, const sample *sample, const sim_reaction *sim_r, double E_front, double E_back, const depth *d_before, const depth *d_after, double S_front, double S_back);
-double cross_section_straggling(const sim_reaction *sim_r, const prob_dist *pd, double E, double S);
+double cross_section_concentration_product_fixed(const sim_workspace *ws, const sample *sample, const sim_reaction *sim_r, double E_front, double E_back, const depth *d_before, const depth *d_after, double S_front, double S_back);
+double cross_section_concentration_product_adaptive(const sim_workspace *ws, const sample *sample, const sim_reaction *sim_r, double E_front, double E_back, const depth *d_before, const depth *d_after, double S_front, double S_back);
+double cross_section_straggling(const sim_reaction *sim_r, gsl_integration_workspace *w, const prob_dist *pd, double E, double S);
+double cross_section_straggling_fixed(const sim_reaction *sim_r, const prob_dist *pd, double E, double S);
+double cross_section_straggling_adaptive(const sim_reaction *sim_r, gsl_integration_workspace *w, double E, double S);
 fit_params *fit_params_all(fit_data *fit);
 void fit_params_print(const fit_params *params, int active, const char *pattern); /* if active is TRUE print only active variables. pattern can be NULL to bypass matching. */
 void fit_params_print_final(const fit_params *params);

--- a/src/prob_dist.c
+++ b/src/prob_dist.c
@@ -33,8 +33,8 @@ prob_dist *prob_dist_gaussian(size_t n) { /* creates a discrete gaussian (mu = 0
     if(!pd)
         return NULL;
     double sigmas = 0.5 * n; /* number of standard deviations (+/-) around mean. n dependent scaling here means the bin width is one standard deviation */
-    if(sigmas >= 3.5) /* +/- 3.5 sigmas is large enough, use extra bins for extra accuracy */
-        sigmas = 3.5;
+    if(sigmas >= 3.0) /* +/- 3.0 sigmas is large enough, use extra bins for extra accuracy */
+        sigmas = 3.0;
     double low = -1.0 * sigmas;
     double high = 1.0 * sigmas;
     double step = (high - low)/n;

--- a/src/script_command.c
+++ b/src/script_command.c
@@ -1232,6 +1232,7 @@ script_command *script_commands_create(struct script_session *s) {
             {JIBAL_CONFIG_VAR_BOOL,   "beta_manual",          &sim->params->beta_manual,            NULL},
             {JIBAL_CONFIG_VAR_SIZE,   "cs_n_steps",           &sim->params->cs_n_steps,             NULL},
             {JIBAL_CONFIG_VAR_SIZE,   "cs_n_stragg_steps",    &sim->params->cs_n_stragg_steps,      NULL},
+            {JIBAL_CONFIG_VAR_BOOL,   "gaussian_accurate",    &sim->params->gaussian_accurate,      NULL},
             {JIBAL_CONFIG_VAR_NONE, NULL, NULL,                                                     NULL}
     };
     c = script_command_list_from_vars_array(vars, 0);

--- a/src/simulation.c
+++ b/src/simulation.c
@@ -132,7 +132,6 @@ void sim_calc_params_copy(const sim_calc_params *p_src, sim_calc_params *p_dst) 
 }
 
 void sim_calc_params_update(sim_calc_params *p) {
-    assert(p->mean_conc_and_energy || p->cs_n_steps >= 1);
     p->cs_frac = 1.0/(1.0*(p->cs_n_steps+1));
     prob_dist_free(p->cs_stragg_pd);
     p->cs_stragg_pd = prob_dist_gaussian(p->cs_n_stragg_steps);
@@ -142,9 +141,6 @@ void sim_calc_params_update(sim_calc_params *p) {
         p->ds_steps_polar = DUAL_SCATTER_POLAR_STEPS;
     }
     p->n_ds = p->ds_steps_azi *  p->ds_steps_polar;
-#ifdef DEBUG
-    fprintf(stderr, "Calculation parameters (%p) updated. DS %i (%p).\n", (void *)p, p->ds, (void *) &p->ds);
-#endif
 }
 
 void sim_calc_params_ds(sim_calc_params *p, int ds) {
@@ -156,7 +152,7 @@ void sim_calc_params_ds(sim_calc_params *p, int ds) {
 void sim_calc_params_faster(sim_calc_params *p, int fast) {
     if(!p)
         return;
-    if (fast) {
+    if(fast) {
         p->rk4 = FALSE;
         p->nucl_stop_accurate = FALSE;
         p->mean_conc_and_energy = TRUE;
@@ -561,6 +557,8 @@ void sim_workspace_calculate_sum_spectra(sim_workspace *ws) {
     }
 }
 
+
+
 void simulation_print(FILE *f, const simulation *sim) {
     if(!sim) {
         return;
@@ -608,17 +606,17 @@ void simulation_print(FILE *f, const simulation *sim) {
     }
     jabs_message(MSG_INFO, f, "n_reactions = %zu\n", sim->n_reactions);
     jabs_message(MSG_INFO, f, "fluence = %e (%.5lf p-uC)\n", sim->fluence, sim->fluence*C_E*1.0e6);
-    jabs_message(MSG_INFO, f, "step for incident ions = %.3lf keV\n", sim->params->stop_step_incident/C_KEV);
-    jabs_message(MSG_INFO, f, "step for exiting ions = %.3lf keV\n", sim->params->stop_step_exiting/C_KEV);
+    jabs_message(MSG_INFO, f, "step for incident ions = %.3lf keV (0 = auto)\n", sim->params->stop_step_incident/C_KEV);
+    jabs_message(MSG_INFO, f, "step for exiting ions = %.3lf keV (0 = auto)\n", sim->params->stop_step_exiting/C_KEV);
     jabs_message(MSG_INFO, f, "stopping step fudge factor = %g\n", sim->params->stop_step_fudge_factor);
-    jabs_message(MSG_INFO, f, "stopping step minimum = %.3lf keV\n", sim->params->stop_step_min / C_KEV);
+    jabs_message(MSG_INFO, f, "stopping step minimum = %.3lf keV (0 = auto)\n", sim->params->stop_step_min / C_KEV);
     jabs_message(MSG_INFO, f, "stopping RK4 = %s\n", sim->params->rk4?"true":"false");
     jabs_message(MSG_INFO, f, "depth steps max = %zu\n", sim->params->depthsteps_max);
 
     jabs_message(MSG_INFO, f, "cross section of brick determined using mean concentration and energy = %s\n", sim->params->mean_conc_and_energy?"true":"false");
     if(!sim->params->mean_conc_and_energy) {
-        jabs_message(MSG_INFO, f, "concentration * cross section steps per brick = %zu\n", sim->params->cs_n_steps);
-        jabs_message(MSG_INFO, f, "straggling substeps = %zu\n", sim->params->cs_n_stragg_steps);
+        jabs_message(MSG_INFO, f, "concentration * cross section steps per brick = %zu (0 = adaptive)\n", sim->params->cs_n_steps);
+        jabs_message(MSG_INFO, f, "straggling substeps = %zu (0 = adaptive)\n", sim->params->cs_n_stragg_steps);
     }
     jabs_message(MSG_INFO, f, "accurate nuclear stopping = %s\n", sim->params->nucl_stop_accurate?"true":"false");
 

--- a/src/simulation.c
+++ b/src/simulation.c
@@ -101,9 +101,9 @@ sim_calc_params *sim_calc_params_defaults_fast(sim_calc_params *p) {
 
 sim_calc_params *sim_calc_params_defaults_accurate(sim_calc_params *p) {
     sim_calc_params_defaults(p);
-    p->cs_n_steps += 2;
-    p->cs_n_stragg_steps += 2;
-    p->stop_step_fudge_factor *= 0.5;
+    p->cs_n_steps = 0; /* Automatic (adaptive) */
+    p->cs_n_stragg_steps = p->cs_n_stragg_steps*4 + 1;
+    p->stop_step_fudge_factor *= 0.25;
     p->sigmas_cutoff += 1.0;
     return p;
 }
@@ -486,6 +486,8 @@ sim_workspace *sim_workspace_init(const jibal *jibal, const simulation *sim, con
         }
         ws->n_reactions++;
     }
+    ws->n_integration_intervals_max = CS_INTEGRATION_INTERVALS;
+    ws->w_integration = gsl_integration_workspace_alloc (ws->n_integration_intervals_max);
     return ws;
 }
 
@@ -509,6 +511,7 @@ void sim_workspace_free(sim_workspace *ws) {
     }
     free(ws->ion.nucl_stop);
     free(ws->reactions);
+    gsl_integration_workspace_free(ws->w_integration);
     free(ws);
 }
 

--- a/src/simulation.h
+++ b/src/simulation.h
@@ -42,6 +42,7 @@ typedef struct {
     int mean_conc_and_energy; /* Calculation of cross-section concentration product is simplified by calculating cross section at mean energy of a depth step and concentration at mid-bin (only relevant for samples with concentration gradients) */
     int geostragg; /* Geometric straggling true/false */
     int beta_manual; /* Don't calculate exit angle based on detector geometry, use something given by user, true/false */
+    int gaussian_accurate; /* If this is FALSE an approximative gaussian CDF is used in convolution of spectra, otherwise function from GSL is used. */
     double stop_step_incident;
     double stop_step_exiting;
     double stop_step_fudge_factor;
@@ -111,8 +112,8 @@ typedef struct {
     const jibal_isotope *isotopes;
     sim_calc_params *params;
     double emin;
-    size_t n_integration_intervals_max;
-    gsl_integration_workspace *w_integration;
+    gsl_integration_workspace *w_int_cs; /* Integration workspace for conc * cross section product */
+    gsl_integration_workspace *w_int_cs_stragg;
 } sim_workspace;
 
 

--- a/src/simulation.h
+++ b/src/simulation.h
@@ -15,6 +15,7 @@
 #define JABS_SIMULATION_H
 
 #include <gsl/gsl_histogram.h>
+#include <gsl/gsl_integration.h>
 #include <jibal.h>
 #include <time.h>
 
@@ -110,6 +111,8 @@ typedef struct {
     const jibal_isotope *isotopes;
     sim_calc_params *params;
     double emin;
+    size_t n_integration_intervals_max;
+    gsl_integration_workspace *w_integration;
 } sim_workspace;
 
 


### PR DESCRIPTION
This PR includes new adaptive integration routines that should compute number of counts in spectra more accurately. This is useful mainly for benchmarking and in case there are sharp features in cross sections. Spectral shape (gaussian) approximations can also be disabled. The changes here should not affect the default behaviour, but need to be explicitly  activated, e.g. by `set simulation accurate` script command.